### PR TITLE
Removed ToString() cast in navigation parameters

### DIFF
--- a/Template10Library/Services/NavigationService/NavigatedEventArgs.cs
+++ b/Template10Library/Services/NavigationService/NavigatedEventArgs.cs
@@ -10,7 +10,7 @@ namespace Template10.Services.NavigationService
         public NavigatedEventArgs(NavigationEventArgs e)
         {
             this.PageType = e.SourcePageType;
-            this.Parameter = e.Parameter?.ToString();
+            this.Parameter = e.Parameter;
             this.NavigationMode = e.NavigationMode;
         }
         public NavigationMode NavigationMode { get; set; }

--- a/Template10Library/Services/NavigationService/NavigatingEventArgs.cs
+++ b/Template10Library/Services/NavigationService/NavigatingEventArgs.cs
@@ -10,7 +10,7 @@ namespace Template10.Services.NavigationService
         {
             this.NavigationMode = e.NavigationMode;
             this.PageType = e.SourcePageType;
-            this.Parameter = e.Parameter?.ToString();
+            this.Parameter = e.Parameter;
         }
         public bool Cancel { get; set; } = false;
         public bool Suspending { get; set; } = false;


### PR DESCRIPTION
By removing the ToString() cast in navigation parameters, you are able to pass also complex objects and not plain strings between one page to the other.
