### PR TITLE
Navigation enhancements

### DIFF
--- a/Samples/Tiles/Tiles.csproj
+++ b/Samples/Tiles/Tiles.csproj
@@ -140,6 +140,9 @@
     <SDKReference Include="BehaviorsXamlSDKManaged, Version=12.0">
       <Name>Behaviors SDK %28XAML%29</Name>
     </SDKReference>
+    <SDKReference Include="Microsoft.VCLibs, Version=14.0">
+      <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
+    </SDKReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -136,14 +136,7 @@ namespace Template10.Common
         protected sealed override void OnWindowCreated(WindowCreatedEventArgs args)
         {
             var window = new WindowWrapper(args.Window);
-            if (UseAccentColorForTitleBar)
-            {
-                ApplicationViewTitleBar titlebar = ApplicationView.GetForCurrentView().TitleBar;
-                titlebar.BackgroundColor = (Color)Current.Resources["SystemAccentColor"];
-                titlebar.ForegroundColor = Colors.White;
-                titlebar.ButtonBackgroundColor = (Color)Current.Resources["SystemAccentColor"];
-                titlebar.ButtonForegroundColor = Colors.White;
-            }
+            
             WindowCreated?.Invoke(this, args);
             base.OnWindowCreated(args);
         }
@@ -204,6 +197,14 @@ namespace Template10.Common
                     }
             }
 
+            if (UseAccentColorForTitleBar)
+            {
+                ApplicationViewTitleBar titlebar = ApplicationView.GetForCurrentView().TitleBar;
+                titlebar.BackgroundColor = (Color)Current.Resources["SystemAccentColor"];
+                titlebar.ForegroundColor = Colors.White;
+                titlebar.ButtonBackgroundColor = (Color)Current.Resources["SystemAccentColor"];
+                titlebar.ButtonForegroundColor = Colors.White;
+            }
 
             // ensure active (this will hide any custom splashscreen)
             Window.Current.Activate();

--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Windows.Foundation.Metadata;
 using Template10.Services.NavigationService;
+using Windows.UI.ViewManagement;
+using Windows.UI;
 
 namespace Template10.Common
 {
@@ -123,12 +125,25 @@ namespace Template10.Common
             Window.Current.Activate();
         }
 
+        // Added this for programmer's benefit,
+        // Allows developers to use an easy default,
+        // Or change it to suit their app's theme.
+        // This is good.
+        public bool UseAccentColorForTitleBar { get; set; } = true;
         #endregion
 
         public event EventHandler<WindowCreatedEventArgs> WindowCreated;
         protected sealed override void OnWindowCreated(WindowCreatedEventArgs args)
         {
             var window = new WindowWrapper(args.Window);
+            if (UseAccentColorForTitleBar)
+            {
+                ApplicationViewTitleBar titlebar = ApplicationView.GetForCurrentView().TitleBar;
+                titlebar.BackgroundColor = (Color)Current.Resources["SystemAccentColor"];
+                titlebar.ForegroundColor = Colors.White;
+                titlebar.ButtonBackgroundColor = (Color)Current.Resources["SystemAccentColor"];
+                titlebar.ButtonForegroundColor = Colors.White;
+            }
             WindowCreated?.Invoke(this, args);
             base.OnWindowCreated(args);
         }

--- a/Template10 (Library)/Controls/PageHeader.xaml
+++ b/Template10 (Library)/Controls/PageHeader.xaml
@@ -11,8 +11,8 @@
     mc:Ignorable="d" MinHeight="48" d:DesignWidth="400" x:Name="ThisPage">
 
     <UserControl.Resources>
-        <SolidColorBrush x:Name="HeaderBackgroundBrush" Color="Gainsboro" />
-        <SolidColorBrush x:Name="HeaderForegroundBrush" Color="Black" />
+        <SolidColorBrush x:Name="HeaderBackgroundBrush" Color="{ThemeResource SystemAccentColor}" />
+        <SolidColorBrush x:Name="HeaderForegroundBrush" Color="{ThemeResource SystemBaseHighColor}" />
     </UserControl.Resources>
 
     <CommandBar x:Name="HeaderCommandBar" DataContext="{Binding ElementName=ThisPage}" 

--- a/Template10 (Library)/Controls/PageHeader.xaml
+++ b/Template10 (Library)/Controls/PageHeader.xaml
@@ -12,7 +12,7 @@
 
     <UserControl.Resources>
         <SolidColorBrush x:Name="HeaderBackgroundBrush" Color="{ThemeResource SystemAccentColor}" />
-        <SolidColorBrush x:Name="HeaderForegroundBrush" Color="{ThemeResource SystemBaseHighColor}" />
+        <SolidColorBrush x:Name="HeaderForegroundBrush" Color="White" />
     </UserControl.Resources>
 
     <CommandBar x:Name="HeaderCommandBar" DataContext="{Binding ElementName=ThisPage}" 

--- a/Template10 (Library)/Controls/PageHeader.xaml.cs
+++ b/Template10 (Library)/Controls/PageHeader.xaml.cs
@@ -22,6 +22,24 @@ namespace Template10.Controls
             PrimaryCommands = HeaderCommandBar.PrimaryCommands;
             SecondaryCommands = HeaderCommandBar.SecondaryCommands;
             this.Background = HeaderCommandBar.Background;
+            
+            // Show header back button based on BootStrapper's ShowShellBackButton property.
+            // WIP: Still haven't quite figured out how to
+            // Update this when the setting changes,
+            // Using a dash of MVVM magic, maybe?
+            if (BootStrapper.Current.ShowShellBackButton)
+            {
+                //Shell back button is enabled,
+                //Disable this back button.
+                this.BackButtonVisibility = Visibility.Collapsed;
+            }
+            else
+            {
+                // Shell back button is disabled,
+                // Enable this one.
+                this.BackButtonVisibility = Visibility.Visible;
+            }
+
             HeaderCommandBar.SetBinding(CommandBar.BackgroundProperty, new Binding
             {
                 Path = new PropertyPath(nameof(Background)),

--- a/Template10 (Library)/Template10 (Library).csproj
+++ b/Template10 (Library)/Template10 (Library).csproj
@@ -179,6 +179,9 @@
     <SDKReference Include="BehaviorsXamlSDKManaged, Version=12.0">
       <Name>Behaviors SDK %28XAML%29</Name>
     </SDKReference>
+    <SDKReference Include="Microsoft.VCLibs, Version=14.0">
+      <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
+    </SDKReference>
     <SDKReference Include="WindowsMobile, Version=10.0.10240.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>

--- a/Template10 (Services)/Template10 (Services).csproj
+++ b/Template10 (Services)/Template10 (Services).csproj
@@ -158,6 +158,11 @@
     <Compile Include="WindowService\WindowService.cs" />
     <Content Include="Properties\Template10.Services.rd.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <SDKReference Include="Microsoft.VCLibs, Version=14.0">
+      <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
+    </SDKReference>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/Templates (Project)/Blank/Blank.csproj
+++ b/Templates (Project)/Blank/Blank.csproj
@@ -131,6 +131,9 @@
     <SDKReference Include="BehaviorsXamlSDKManaged, Version=12.0">
       <Name>Behaviors SDK %28XAML%29</Name>
     </SDKReference>
+    <SDKReference Include="Microsoft.VCLibs, Version=14.0">
+      <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
+    </SDKReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Templates (Project)/Minimal/Minimal.csproj
+++ b/Templates (Project)/Minimal/Minimal.csproj
@@ -174,6 +174,9 @@
     <SDKReference Include="BehaviorsXamlSDKManaged, Version=12.0">
       <Name>Behaviors SDK %28XAML%29</Name>
     </SDKReference>
+    <SDKReference Include="Microsoft.VCLibs, Version=14.0">
+      <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
+    </SDKReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>


### PR DESCRIPTION
This includes some nice changes. PageHeader now automagically hides it's own back button (on init only) when the BootStrapper has UseShellBackButton enabled. This commit allows adds a new boolean to BootStrapper, which controls a nice new feature. By default, the users accent color will be set as the window title bar color during startup. However, this can be disabled by toggling this Boolean. Clever, eh?
