### PR TITLE
Prevent hamburger menu be opened when TextBox's keydown firing

### DIFF
--- a/Template10 (Library)/Behaviors/TextBoxEnterKeyBehavior.cs
+++ b/Template10 (Library)/Behaviors/TextBoxEnterKeyBehavior.cs
@@ -17,15 +17,15 @@ namespace Template10.Behaviors
         public void Attach(DependencyObject associatedObject)
         {
             AssociatedObject = associatedObject;
-            AssociatedTextBox.KeyDown += AssociatedTextBox_KeyDown;
+            AssociatedTextBox.KeyUp += AssociatedTextBox_KeyUp;
         }
 
         public void Detach()
         {
-            AssociatedTextBox.KeyDown -= AssociatedTextBox_KeyDown;
+            AssociatedTextBox.KeyUp -= AssociatedTextBox_KeyUp;
         }
 
-        private void AssociatedTextBox_KeyDown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
+        private void AssociatedTextBox_KeyUp(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
             if (e.Key == Windows.System.VirtualKey.Enter)
             {


### PR DESCRIPTION
Fix issue #61 

Due to an [internal bug](https://social.msdn.microsoft.com/Forums/en-US/734d6c7a-8da2-48c6-9b3d-fa868b4dfb1d/c-textbox-keydown-triggered-twice-in-metro-applications?forum=winappswithcsharp) of WinRT, the KeyDown event of TextBox will be triggered twice. When the second time of KeyDown fired, the frame has been navigated to another page, but the event still propagates and then intercepted by other controls. In this case, the hamburger button handles it, so the pane is opened.

I replace KeyDown with KeyUp in this patch, and it works fine on both PC and phone :)
