### PR TITLE
Bootstrapper.cs remove dependancy on WindowsMobile

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -196,37 +196,49 @@ namespace Template10.Common
             Window.Current.Activate();
 
             // Hook up the default Back handler
-            global::Windows.UI.Core.SystemNavigationManager.GetForCurrentView().BackRequested += (s, args) =>
+            SystemNavigationManager.GetForCurrentView().BackRequested += (s, args) =>
             {
                 // only handle as long as there is a default backstack
                 //args.Handled = !NavigationService.CanGoBack;
                 var handled = false;
-                RaiseBackRequested(ref handled);
+                if (ApiInformation.IsApiContractPresent("Windows.Phone.PhoneContract", 1, 0))
+                {
+                    if (NavigationService.CanGoBack)
+                    {
+                        handled = true;
+                    }
+                }
+                else
+                {
+                    handled = !NavigationService.CanGoBack;
+                }
+
                 args.Handled = handled;
+                RaiseBackRequested(ref handled);
             };
 
             // Hook up keyboard and mouse Back handler
-            var keyboard = new Services.KeyboardService.KeyboardService();
+            var keyboard = new KeyboardService();
             keyboard.AfterBackGesture = () =>
-                                        {
-                                            //the result is no matter
-                                            var handled = false;
-                                            RaiseBackRequested(ref handled);
-                                        };
+            {
+                //the result is no matter
+                var handled = false;
+                RaiseBackRequested(ref handled);
+            };
 
             // Hook up keyboard and mouse Forward handler
-            keyboard.AfterForwardGesture = () => RaiseForwardRequested();
+            keyboard.AfterForwardGesture = RaiseForwardRequested;
 
-            // Handle the back button press on Mobile
-            if (ApiInformation.IsApiContractPresent("Windows.Phone.PhoneContract", 1, 0))
-            {
-                Windows.Phone.UI.Input.HardwareButtons.BackPressed += (s, a) =>
-                {
-                    bool handled = false;
-                    RaiseBackRequested(ref handled);
-                    a.Handled = handled;
-                };
-            }
+            //// Handle the back button press on Mobile
+            //if (ApiInformation.IsApiContractPresent("Windows.Phone.PhoneContract", 1, 0))
+            //{
+            //    HardwareButtons.BackPressed += (s, a) =>
+            //    {
+            //        var handled = false;
+            //        RaiseBackRequested(ref handled);
+            //        a.Handled = handled;
+            //    };
+            //}
         }
 
         #endregion


### PR DESCRIPTION
This is the change I make to the BootStrapper.cs file to remove the dependency on "Windows Mobile Extensions for the UWP"

I have tested this in the phone emulators, but on a real/actual phone, but in the phone emulators I get the expected/desired behaviour from the Back-Button
