### PR TITLE
Update BootStrapper.cs

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -12,6 +12,7 @@ using Windows.Foundation.Metadata;
 using Template10.Services.NavigationService;
 using Windows.UI.ViewManagement;
 using Template10.Utils;
+using Template10.Services.KeyboardService;
 
 namespace Template10.Common
 {


### PR DESCRIPTION
added

```
using Template10.Services.KeyboardService;
```

to fix compiling issue on 

```
var keyboard = new KeyboardService();
```
