### PR TITLE
Update HamburgerMenu Test for PageParam changed

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -36,9 +36,10 @@ namespace Template10.Controls
 
         public void HighlightCorrectButton()
         {
-            var type = NavigationService.Frame.Content?.GetType();
+            var pageType = NavigationService.CurrentPageType;
+            var pageParam = NavigationService.CurrentPageParam;
             var values = _navButtons.Select(x => x.Value);
-            var button = values.FirstOrDefault(x => type.Equals(x.PageType));
+            var button = values.FirstOrDefault(x => x.PageType == pageType && x.PageParameter == pageParam);
             Selected = button;
         }
 
@@ -245,10 +246,11 @@ namespace Template10.Controls
                     value.RaiseSelected();
 
                 // navigate only to new pages
-                if (value.PageType != null && NavigationService.CurrentPageType != value.PageType)
+                if (value.PageType != null && (NavigationService.CurrentPageType != value.PageType || NavigationService.CurrentPageParam != value.PageParameter))
                 {
                     NavigationService.Navigate(value.PageType, value.PageParameter);
                     value.IsEnabled = false;
+                    HighlightCorrectButton();
                 }
             }
         }


### PR DESCRIPTION
The HamburgerMenu currently only tests for a new PageType when a menu button is clicked/tapped therefore will not update correctly if you have a situation where you have multi menu items with the same PageType but different PageParam values

Also the menu will not navigate to the same view that has a different parameter passed to it as in this example below
where you have two menu options which navigate to the same view but with different parameters

```
            <Controls:HamburgerButtonInfo ClearHistory="True" PageType="views:DetailPage" PageParameter="A">
                <StackPanel Orientation="Horizontal">
                    <SymbolIcon Width="48" Height="48" Symbol="Comment" />
                    <TextBlock Margin="12,0,0,0" VerticalAlignment="Center" Text="Comment A" />
                </StackPanel>
            </Controls:HamburgerButtonInfo>

            <Controls:HamburgerButtonInfo ClearHistory="True" PageType="views:DetailPage" PageParameter="B">
                <StackPanel Orientation="Horizontal">
                    <SymbolIcon Width="48" Height="48" Symbol="Comment" />
                    <TextBlock Margin="12,0,0,0" VerticalAlignment="Center" Text="Comment B" />
                </StackPanel>
            </Controls:HamburgerButtonInfo>
        </Controls:HamburgerMenu.PrimaryButtons>
```

You could have this scenario as above with hardcoded xaml menu items or if you are pulling information from an API or database to create menu options

In the proposed change I have added the test to include the page parameter and also update the correct "selected" menu item

I also notice there is an issue with the back navigation not highlighting the previous selected menu item after the page has navigated back from a previous page... I have not found a solution/fix for that in this change
