### PR TITLE
Adding the ability to associate a key to a page to allow navigation without specifying the page type.

### DIFF
--- a/Template10 (Library)/Services/NavigationService/INavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/INavigationService.cs
@@ -22,8 +22,11 @@ namespace Template10.Services.NavigationService
         void ClearHistory();
         void GoBack();
         void GoForward();
+        void Register(string key, Type page);
         bool Navigate(Type page, object parameter = null, NavigationTransitionInfo infoOverride = null);
+        bool Navigate(string pageKey, object parameter = null, NavigationTransitionInfo infoOverride = null);
         Task OpenAsync(Type page, object parameter = null, string title = null, ViewSizePreference size = ViewSizePreference.UseHalf);
+        Task OpenAsync(string pageKey, object parameter = null, string title = null, ViewSizePreference size = ViewSizePreference.UseHalf);
         void Refresh();
         bool RestoreSavedNavigation();
         void Resuming();

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -18,6 +18,8 @@ namespace Template10.Services.NavigationService
     // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
     public class NavigationService : INavigationService
     {
+        private readonly Dictionary<string, Type> pagesByKey = new Dictionary<string, Type>(StringComparer.CurrentCultureIgnoreCase);
+
         private const string EmptyNavigation = "1,0";
 
         public FrameFacade FrameFacade { get; private set; }
@@ -224,6 +226,32 @@ namespace Template10.Services.NavigationService
                 dataContext.OnNavigatedTo(parameter, NavigationMode.New, null);
             }
             flyout.Show();
+        }
+
+        public void Register(string key, Type page)
+        {
+            pagesByKey[key] = page;
+        }
+
+        public bool Navigate(string pageKey, object parameter = null, NavigationTransitionInfo infoOverride = null)
+        {
+            var page = GetPageByKey(pageKey);
+            return Navigate(page, parameter, infoOverride);
+        }
+
+        public Task OpenAsync(string pageKey, object parameter = null, string title = null, ViewSizePreference size = ViewSizePreference.UseHalf)
+        {
+            var page = GetPageByKey(pageKey);
+            return OpenAsync(page, parameter, title, size);
+        }
+
+        private Type GetPageByKey(string pageKey)
+        {
+            Type page;
+            if (!pagesByKey.TryGetValue(pageKey, out page))
+                throw new ArgumentException($"No page registered with key '{pageKey}'");
+
+            return page;
         }
 
         public Type CurrentPageType { get { return FrameFacade.CurrentPageType; } }


### PR DESCRIPTION
This is useful for example when using NavigationService from a ViewModel in an MVVM scenario: in this case, the ViewModel shouldn't know anything about pages.
