### PR TITLE
Updated readme.md to explain how to use PageKeys for navigation

### DIFF
--- a/Samples/PageKeys/Readme.md
+++ b/Samples/PageKeys/Readme.md
@@ -1,31 +1,33 @@
 ﻿#PageKeys
 
-Template 10 allows developers to navigate by page type (which is standard on the XAML Frame) and by key. Using a key allows developers to isolate view types from view models. This is a common approach for developer implementing MVVM. But, this approach is not necessary to successfully use Template 10.
+Template 10 allows developers to navigate by page type (which is standard on the XAML Frame) and by key. Using a key allows developers to isolate view types from view models. This is a common approach for developers implementing MVVM (but is not necessary to successfully use Template 10).
 
 ##Pages Enum
 
-Lorem ipsum...
+The first step is creating a custom Enum that represents the pages we want to navigate to.
 
 ````chsarp
-public enum Pages { MainPage }
+public enum Pages { MainPage, DetailPage }
 ````
 
 ##BootStrapper.PageKeys<T>()
 
-Lorem ipsum...
+Then, tipically in the BootStrapper.OnInitializeAsync, we populate the BootStrapper.PageKeys dictionary associating each page type with the corresponding enum value.
 
 ````chsarp
 public override Task OnInitializeAsync(IActivatedEventArgs args)
 {
     var keys = PageKeys<Pages>();
-    keys.Add(Pages.MainPage, typeof(Views.MainPage));
+    keys.Add(Pages.MainPage, typeof(MainPage));
+    keys.Add(Pages.DetailPage, typeof(DetailPage));
+
     return base.OnInitializeAsync(args);
 }
 ````
 
 ##NavigationSerice.Navigate<T>()
 
-Lorem ipsum...
+In this way, we can use an overload of the NavigationService.Navigate method that takes as first argument the enum value corresponding to the page type we want to navigate to.
 
 ````chsarp
 public override Task OnStartAsync(StartKind startKind, IActivatedEventArgs args)
@@ -34,3 +36,5 @@ public override Task OnStartAsync(StartKind startKind, IActivatedEventArgs args)
     return Task.FromResult<object>(null);
 }
 ````
+
+When we follow the MVVM pattern, this is the recommended approach to navigation because view models shouldn't know anything about page types.

--- a/Samples/PageKeys/Readme.md
+++ b/Samples/PageKeys/Readme.md
@@ -25,7 +25,7 @@ public override Task OnInitializeAsync(IActivatedEventArgs args)
 }
 ````
 
-##NavigationSerice.Navigate<T>()
+##NavigationService.Navigate<T>()
 
 In this way, we can use an overload of the NavigationService.Navigate method that takes as first argument the enum value corresponding to the page type we want to navigate to (instead of use the page type directly).
 

--- a/Samples/PageKeys/Readme.md
+++ b/Samples/PageKeys/Readme.md
@@ -12,7 +12,7 @@ public enum Pages { MainPage, DetailPage }
 
 ##BootStrapper.PageKeys<T>()
 
-Then, tipically in the BootStrapper.OnInitializeAsync, we populate the BootStrapper.PageKeys dictionary associating each page type with the corresponding enum value.
+Then, tipically in the BootStrapper.OnInitializeAsync method, we populate the BootStrapper.PageKeys dictionary associating each page type with the corresponding enum value.
 
 ````chsarp
 public override Task OnInitializeAsync(IActivatedEventArgs args)
@@ -27,7 +27,7 @@ public override Task OnInitializeAsync(IActivatedEventArgs args)
 
 ##NavigationSerice.Navigate<T>()
 
-In this way, we can use an overload of the NavigationService.Navigate method that takes as first argument the enum value corresponding to the page type we want to navigate to.
+In this way, we can use an overload of the NavigationService.Navigate method that takes as first argument the enum value corresponding to the page type we want to navigate to (instead of use the page type directly).
 
 ````chsarp
 public override Task OnStartAsync(StartKind startKind, IActivatedEventArgs args)
@@ -37,4 +37,4 @@ public override Task OnStartAsync(StartKind startKind, IActivatedEventArgs args)
 }
 ````
 
-When we follow the MVVM pattern, this is the recommended approach to navigation because view models shouldn't know anything about page types.
+When we follow the MVVM pattern, this is the recommended approach for navigation because view models shouldn't know anything about page types.

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -163,7 +163,7 @@ namespace Template10.Services.NavigationService
             public Enum Pages { MainPage, DetailPage }
 
             // setup the keys dict
-            var keys = NavigationService.PageKeys<Views>();
+            var keys = BootStrapper.PageKeys<Views>();
             keys.Add(Pages.MainPage, typeof(Views.MainPage));
             keys.Add(Pages.DetailPage, typeof(Views.DetailPage));
 


### PR DESCRIPTION
This approach allows navigation by key instead of page types (This is useful for example when using NavigationService from a View Model in an MVVM scenario).
