### PR TITLE
Correcting System.InvalidCastException when accessing the PaneWidth p…

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -407,7 +407,7 @@ namespace Template10.Controls
         }
         public static readonly DependencyProperty PaneWidthProperty =
             DependencyProperty.Register("PaneWidth", typeof(double),
-                typeof(HamburgerMenu), new PropertyMetadata(220));
+                typeof(HamburgerMenu), new PropertyMetadata(220d));
 
         public UIElement HeaderContent
         {


### PR DESCRIPTION
While for a lookout in HamburgerMenu code relating to my posting under #155 I came across a small bug (call it a bugette ;-) that is self-correcting and therefore hard to detect.

Attempting to access the PaneWidth property of HamburgerMenu before navigating to another page (ShellSplitView.IsPaneOpen == false ) throws an exception of System.InvalidCastException("Specified cast is not valid"). (This may have an impact in HamburgerMenu.xaml Binding but haven't checked thoroughly;  interestingly, in previous versions this was FURTHER disguised by a FallbackValue for the binding).

If navigated from the landing page, MainPage.xaml, (with ShellSplitView.IsPaneOpen == true) the problem corrects itself as PaneWidth is explicitly initialized by the NavigationService property setter, hence hiding the problem.

As it happens, this is a single letter correction (you can't beat this as the smallest pull request!): the default value of 220 passed on to the PaneWidth DependencyProperty should be set as 220d with the double suffix d. This is a well known oversight as well explained here: http://reedcopsey.com/2009/10/23/wpf-common-dependency-property-exception/ as to how the missing suffix d leads to System.InvalidCastException.

Surely some feedback for the compiler design team as coding for DependencyProperty has unambiguous declaration with typeof(double) which the compiler can easily deduce (or at least issue a warning).
