### PR TITLE
CompactInline-CompactOverlay toggle menu mode

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -178,7 +178,7 @@
     <Grid x:Name="RootGrid">
 
         <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="VisualStateGroup">
+            <VisualStateGroup x:Name="VisualStateGroup" CurrentStateChanged="OnVisualStateGroupChanged">
 
                 <VisualStateGroup.Transitions>
                     <VisualTransition GeneratedDuration="0" To="VisualStateWide">
@@ -220,10 +220,29 @@
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger x:Name="VisualStateWideTrigger" MinWindowWidth="-1" />
                     </VisualState.StateTriggers>
+                </VisualState>
+
+            </VisualStateGroup>
+
+            <!-- Visual states for menu mode -->
+
+            <VisualStateGroup>
+                
+                <VisualState x:Name="WideVisualStateCompactInline">
                     <VisualState.Setters>
                         <Setter Target="ShellSplitView.DisplayMode" Value="CompactInline" />
                         <Setter Target="HamburgerButton.Visibility" Value="Collapsed" />
                         <Setter Target="ShellSplitView.IsPaneOpen" Value="True" />
+                        <Setter Target="HamburgerButton.Visibility" Value="Collapsed" />
+                    </VisualState.Setters>
+                </VisualState>
+
+
+                <VisualState x:Name="WideVisualStateCompactOverlay">
+                    <VisualState.Setters>
+                        <Setter Target="ShellSplitView.DisplayMode" Value="CompactOverlay" />
+                        <Setter Target="ShellSplitView.IsPaneOpen" Value="False" />
+                        <Setter Target="HamburgerButton.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>
 

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -514,5 +514,47 @@ namespace Template10.Controls
         {
             _SecondaryButtonStackPanel = sender as StackPanel;
         }
+
+        public bool IsCompactOverlayForWideVisual
+        {
+            get { return (bool)GetValue(IsCompactOverlayWhenWideProperty); }
+            set { SetValue(IsCompactOverlayWhenWideProperty, value); }
+        }
+
+        public readonly static DependencyProperty IsCompactOverlayWhenWideProperty =
+            DependencyProperty.Register(nameof(IsCompactOverlayForWideVisual), typeof(bool),
+                typeof(HamburgerMenu), new PropertyMetadata(false, OnWideVisualStateModeChanged));
+
+        private void OnVisualStateGroupChanged(object sender, VisualStateChangedEventArgs e)
+        {
+            if (e.NewState != this.VisualStateWide) return;
+
+            if (IsCompactOverlayForWideVisual)
+            {
+                VisualStateManager.GoToState(this, WideVisualStateCompactOverlay.Name, false);
+            }
+            else
+            {
+                VisualStateManager.GoToState(this, WideVisualStateCompactInline.Name, false);
+            }
+        }
+
+        private static void OnWideVisualStateModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            HamburgerMenu hm = d as HamburgerMenu;
+
+            if (hm.ActualWidth >= hm.VisualStateWideMinWidth)
+            {
+                bool isCompactOverlay = (bool)e.NewValue;
+
+                if (isCompactOverlay)
+                {
+                    VisualStateManager.GoToState(hm, hm.WideVisualStateCompactOverlay.Name, true);
+                }else
+                {
+                    VisualStateManager.GoToState(hm, hm.WideVisualStateCompactInline.Name, true);
+                }
+            }
+        }
     }
 }

--- a/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
+++ b/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
@@ -43,5 +43,12 @@ namespace Sample.Services.SettingsServices
         {
             Template10.Common.BootStrapper.Current.CacheMaxDuration = value;
         }
+
+        private void ApplyCompactMenuForWideScreen(bool value)
+        {
+            Views.Shell.ApplyCompactOverlayForWideVisual(value);
+        }
+        
+
     }
 }

--- a/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.cs
+++ b/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.cs
@@ -54,5 +54,15 @@ namespace Sample.Services.SettingsServices
                 ApplyCacheMaxDuration(value);
             }
         }
+
+        public bool UseCompactMenuForWideScreen
+        {
+            get { return _helper.Read<bool>(nameof(UseCompactMenuForWideScreen), false); }
+            set
+            {
+                _helper.Write(nameof(UseCompactMenuForWideScreen), value);
+                ApplyCompactMenuForWideScreen(value);
+            }
+        }
     }
 }

--- a/Templates (Project)/Minimal/Styles/Custom.xaml
+++ b/Templates (Project)/Minimal/Styles/Custom.xaml
@@ -5,6 +5,7 @@
     <x:Double x:Key="NarrowMinWidth">0</x:Double>
     <x:Double x:Key="NormalMinWidth">521</x:Double>
     <x:Double x:Key="WideMinWidth">1200</x:Double>
+    <x:Double x:Key="SettingItemsBorderWidth">264</x:Double>
 
     <SolidColorBrush x:Key="CustomColorBrush" Color="{StaticResource CustomColor}" />
     <SolidColorBrush x:Key="ExtendedSplashBackground" Color="White" />

--- a/Templates (Project)/Minimal/ViewModels/SettingsPageViewModel.cs
+++ b/Templates (Project)/Minimal/ViewModels/SettingsPageViewModel.cs
@@ -47,6 +47,12 @@ namespace Sample.ViewModels
         {
             Views.Shell.SetBusyVisibility(Visibility.Collapsed);
         }
+
+        public bool UseNarrowMenuPaneForWideVisual
+        {
+            get { return _settings.UseCompactMenuForWideScreen; }
+            set { _settings.UseCompactMenuForWideScreen = value; base.RaisePropertyChanged(); }
+        }
     }
 
     public class AboutPartViewModel : Mvvm.ViewModelBase

--- a/Templates (Project)/Minimal/Views/SettingsPage.xaml
+++ b/Templates (Project)/Minimal/Views/SettingsPage.xaml
@@ -31,18 +31,31 @@
             <PivotItem DataContext="{Binding SettingsPartViewModel}" Header="Settings">
                 <ScrollViewer Margin="0,12,-12,0" HorizontalContentAlignment="Left" VerticalScrollBarVisibility="Auto">
                     <RelativePanel HorizontalAlignment="Left">
-                        <ToggleSwitch x:Name="UseShellDrawnBackButtonToggleSwtich"
-                                      Header="Use shell-drawn back button"
+
+                        <Border x:Name="UseShellDrawnBackButtonToggleSwtichBorder" BorderBrush="Silver" Margin="6,0,0,12" Padding="6" BorderThickness="1" Width="{StaticResource SettingItemsBorderWidth}">
+                            <ToggleSwitch  Header="Use shell-drawn back button"
                                       IsOn="{Binding UseShellBackButton, Mode=TwoWay}"
                                       OffContent="Back button in page header"
                                       OnContent="Back button in titlebar or taskbar" />
-                        <ToggleSwitch x:Name="UseLightThemeToggleSwitch" Header="Use Light Theme"
+                        </Border>
+
+                        <Border x:Name="UseLightThemeToggleSwitchBorder" BorderBrush="Silver" Margin="6,0,0,12" Padding="6" BorderThickness="1" Width="{StaticResource SettingItemsBorderWidth}"  RelativePanel.Below="UseShellDrawnBackButtonToggleSwtichBorder" >
+                            <ToggleSwitch  Header="Use Light Theme"
                                       IsOn="{Binding UseLightThemeButton, Mode=TwoWay}"
-                                      OffContent="Dark theme" OnContent="Light theme"
-                                      RelativePanel.Below="UseShellDrawnBackButtonToggleSwtich" />
+                                           OffContent="Dark theme"
+                                           OnContent="Light theme" />
+                        </Border>
+
+                        <Border x:Name="WideVisualMenuModeToggleSwitchBorder" BorderBrush="Silver" Margin="6,0,0,12" Padding="6" BorderThickness="1" Width="{StaticResource SettingItemsBorderWidth}" RelativePanel.Below="UseLightThemeToggleSwitchBorder">
+                            <ToggleSwitch Header="Menu mode for wide screen"
+                                          IsOn="{Binding UseNarrowMenuPaneForWideVisual, Mode=TwoWay}"
+                                          OffContent="Normal"
+                                          OnContent="Compact" />
+                        </Border>
+                        
                         <TextBox x:Name="BusyTextTextBox" Width="200"
                                  Margin="0,12,0,0" HorizontalAlignment="Left"
-                                 Header="Busy text" RelativePanel.Below="UseLightThemeToggleSwitch"
+                                 Header="Busy text" RelativePanel.Below="WideVisualMenuModeToggleSwitchBorder"
                                  Text="{Binding BusyText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <Button Margin="0,12,0,0" Content="Show Busy Indicator"
                                 RelativePanel.AlignBottomWith="BusyTextTextBox"

--- a/Templates (Project)/Minimal/Views/Shell.xaml
+++ b/Templates (Project)/Minimal/Views/Shell.xaml
@@ -23,7 +23,7 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
-        <Controls:HamburgerMenu x:Name="MyHamburgerMenu" IsEnabled="False">
+        <Controls:HamburgerMenu x:Name="MyHamburgerMenu" IsEnabled="False" IsCompactOverlayForWideVisual="False">
 
             <Controls:HamburgerMenu.PrimaryButtons>
                 <Controls:HamburgerButtonInfo ClearHistory="True" PageType="views:MainPage">

--- a/Templates (Project)/Minimal/Views/Shell.xaml.cs
+++ b/Templates (Project)/Minimal/Views/Shell.xaml.cs
@@ -25,6 +25,7 @@ namespace Sample.Views
             Window = WindowWrapper.Current();
             MyHamburgerMenu.NavigationService = navigationService;
             VisualStateManager.GoToState(Instance, Instance.NormalVisualState.Name, true);
+            ApplyCompactOverlayForWideVisual(Services.SettingsServices.SettingsService.Instance.UseCompactMenuForWideScreen);
         }
 
         public static void SetBusyVisibility(Visibility visible, string text = null)
@@ -43,6 +44,16 @@ namespace Sample.Views
                         break;
                 }
             });
+        }
+
+        public static void ApplyCompactOverlayForWideVisual(bool value)
+        {
+
+            Window.Dispatcher.Dispatch(() =>
+            {
+                Instance.MyHamburgerMenu.IsCompactOverlayForWideVisual = value;
+            });
+
         }
     }
 }


### PR DESCRIPTION
In wide display mode, sometimes it may be desirable to collapse the CompactInline menu to the CompactOverlay mode. This pull request implements a toggle effect (you enable it only when you need it in wide display mode). How about we call it, ... CompactInline - CompactOverlay  or CICO (ouch!! does that remind you of 'model view view model' ? ;-).Anyways, see what you think.

In addition to the main implementation in the HamburgerMenu control (VisualStates and DP's), a setting via Settings Service is also implemented and demonstrated via Minimal template project.
Hope you'll like it..

[Overlay]  [CompactOverlay]  [Compactnline]  [CompactInline-CompactOverlay]  [Inline] ... [Weird, huh!]
