### PR TITLE
PageHeader theme binding fixed and defaults changed; theme switching …

### DIFF
--- a/Template10 (Library)/Controls/PageHeader.xaml
+++ b/Template10 (Library)/Controls/PageHeader.xaml
@@ -10,17 +10,12 @@
              x:Name="ThisPage" MinHeight="48"
              d:DesignWidth="400" mc:Ignorable="d">
 
-    <UserControl.Resources>
-        <SolidColorBrush x:Name="DefaultHeaderBackground" Color="Gainsboro" />
-        <SolidColorBrush x:Name="DefaultHeaderForeground" Color="Black" />
-    </UserControl.Resources>
-
     <CommandBar x:Name="HeaderCommandBar" Grid.Column="0"
                 Grid.ColumnSpan="2"
-                Background="{x:Bind HeaderBackground, FallbackValue=Blue}"
+                Background="{x:Bind HeaderBackground, FallbackValue=Gainsboro, Mode=OneWay}"
                 ClosedDisplayMode="Compact"
                 DataContext="{Binding ElementName=ThisPage}"
-                Foreground="{x:Bind HeaderForeground, FallbackValue=White}">
+                Foreground="{x:Bind HeaderForeground, FallbackValue=Black, Mode=OneWay}">
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="VisualStateGroup">

--- a/Template10 (Library)/Controls/PageHeader.xaml.cs
+++ b/Template10 (Library)/Controls/PageHeader.xaml.cs
@@ -72,20 +72,20 @@ namespace Template10.Controls
 
         public Brush HeaderBackground
         {
-            get { return (Brush)GetValue(HeaderBackgroundProperty) ?? Resources["DefaultHeaderBackground"] as Brush; }
+            get { return (Brush)GetValue(HeaderBackgroundProperty) as Brush; }
             set { SetValue(HeaderBackgroundProperty, value); }
         }
         public static readonly DependencyProperty HeaderBackgroundProperty =
             DependencyProperty.Register(nameof(HeaderBackground), typeof(Brush),
                 typeof(PageHeader), new PropertyMetadata(null));
 
-        public Brush HeaderForeground
+        public SolidColorBrush HeaderForeground
         {
-            get { return (Brush)GetValue(HeaderForegroundProperty) ?? Resources["DefaultHeaderForeground"] as Brush; }
+            get { return GetValue(HeaderForegroundProperty) as SolidColorBrush; }
             set { SetValue(HeaderForegroundProperty, value); }
         }
         public static readonly DependencyProperty HeaderForegroundProperty =
-            DependencyProperty.Register(nameof(HeaderForeground), typeof(Brush),
+            DependencyProperty.Register(nameof(HeaderForeground), typeof(SolidColorBrush),
                 typeof(PageHeader), new PropertyMetadata(null));
 
         public IObservableVector<ICommandBarElement> PrimaryCommands

--- a/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
+++ b/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
@@ -21,22 +21,19 @@ namespace Sample.Services.SettingsServices
 
         public void ApplyAppTheme(ApplicationTheme value)
         {
-            Template10.Common.BootStrapper.Current.NavigationService.Dispatcher.Dispatch(() =>
+
+            switch (value)
             {
-                switch (value)
-                {
-                    case ApplicationTheme.Light:
-                        Views.Shell.Instance.RequestedTheme = ElementTheme.Light;
-                        break;
-                    case ApplicationTheme.Dark:
-                        Views.Shell.Instance.RequestedTheme = ElementTheme.Dark;
-                        break;
-                    default:
-                        Views.Shell.Instance.RequestedTheme = ElementTheme.Default;
-                        break;
-                }
-                Template10.Common.BootStrapper.Current.NavigationService.Refresh();
-            });
+                case ApplicationTheme.Light:
+                    Views.Shell.SetThemeColors(ElementTheme.Light);
+                    break;
+                case ApplicationTheme.Dark:
+                    Views.Shell.SetThemeColors(ElementTheme.Dark);
+                    break;
+                default:
+                    Views.Shell.SetThemeColors(ElementTheme.Default);
+                    break;
+            }
         }
 
         private void ApplyCacheMaxDuration(TimeSpan value)

--- a/Templates (Project)/Minimal/Styles/Custom.xaml
+++ b/Templates (Project)/Minimal/Styles/Custom.xaml
@@ -1,4 +1,6 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:controls="using:Template10.Controls">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+                    xmlns:controls="using:Template10.Controls">
 
     <Color x:Key="CustomColor">OrangeRed</Color>
 
@@ -31,8 +33,24 @@
         <!--  RequestedTheme=Dark  -->
         <ResourceDictionary x:Key="Default">
 
+            <SolidColorBrush x:Key="ExtendedSplashBackground" Color="{ThemeResource SystemAccentColor}" />
+            <SolidColorBrush x:Key="ExtendedSplashForeground" Color="White" />
+            <SolidColorBrush x:Key="ModalBackground" Opacity=".5" Color="{ThemeResource SystemAccentColor}" />
+
+            <Style BasedOn="{StaticResource ResizerStyle}" TargetType="controls:Resizer">
+                <Setter Property="GrabberBrush" Value="{StaticResource CustomColorBrush}" />
+            </Style>
+
             <Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
                 <Setter Property="AccentColor" Value="{StaticResource CustomColor}" />
+                <Setter Property="HamburgerBackground" Value="#FFD13438" />
+                <Setter Property="HamburgerForeground" Value="White" />
+                <Setter Property="NavAreaBackground" Value="#FF2B2B2B" />
+                <Setter Property="NavButtonBackground" Value="#FFD13438" />
+                <Setter Property="NavButtonCheckedBackground" Value="#FF7D1F22" />
+                <Setter Property="NavButtonForeground" Value="White" />
+                <Setter Property="NavButtonHoverBackground" Value="#FF434343" />
+                <Setter Property="SecondarySeparator" Value="Gray" />
             </Style>
 
             <Style BasedOn="{StaticResource PageHeaderStyle}" TargetType="controls:PageHeader">
@@ -40,26 +58,46 @@
                 <Setter Property="HeaderForeground" Value="#FF2B2B2B" />
             </Style>
 
-            <!--<Style BasedOn="{StaticResource ResizerStyle}" TargetType="controls:Resizer">
-                <Setter Property="GrabberBrush" Value="{StaticResource CustomColorBrush}" />
-            </Style>-->
-
         </ResourceDictionary>
 
         <!--  RequestedTheme=Light  -->
         <ResourceDictionary x:Key="Light">
 
-            <Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
-                <Setter Property="AccentColor" Value="{StaticResource CustomColor}" />
-            </Style>
-
-            <Style BasedOn="{StaticResource PageHeaderStyle}" TargetType="controls:PageHeader">
-                <Setter Property="HeaderBackground" Value="WhiteSmoke" />
-                <Setter Property="HeaderForeground" Value="#FF2B2B2B" />
-            </Style>
+            <SolidColorBrush x:Key="ExtendedSplashBackground" Color="White" />
+            <SolidColorBrush x:Key="ExtendedSplashForeground" Color="DimGray" />
+            <SolidColorBrush x:Key="ModalBackground" Opacity=".5" Color="{ThemeResource SystemAccentColor}" />
 
             <Style BasedOn="{StaticResource ResizerStyle}" TargetType="controls:Resizer">
                 <Setter Property="GrabberBrush" Value="{StaticResource CustomColorBrush}" />
+            </Style>
+
+            <Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
+                <Setter Property="AccentColor" Value="{StaticResource CustomColor}" />
+                <Setter Property="HamburgerBackground" Value="Gainsboro" />
+                <Setter Property="HamburgerForeground" Value="Black" />
+                <Setter Property="NavAreaBackground" Value="#FFF2F2F2" />
+                <Setter Property="NavButtonBackground" Value="PowderBlue" />
+                <Setter Property="NavButtonCheckedBackground" Value="PowderBlue" />
+                <Setter Property="NavButtonForeground" Value="Black" />
+                <Setter Property="NavButtonHoverBackground" Value="#FFCCE3F5" />
+                <Setter Property="SecondarySeparator" Value="Gray" />
+            </Style>
+
+            <Style BasedOn="{StaticResource PageHeaderStyle}" TargetType="controls:PageHeader">
+                <Setter Property="HeaderBackground" >
+                    <Setter.Value>
+                        <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                            <GradientBrush.GradientStops>
+                                <GradientStopCollection>
+                                    <GradientStop Color="WhiteSmoke" Offset="0" />
+                                    <GradientStop Color="transparent" Offset="1" />
+                                </GradientStopCollection>
+                            </GradientBrush.GradientStops>
+                        </LinearGradientBrush>
+                    </Setter.Value>
+                </Setter>
+
+                 <Setter Property="HeaderForeground" Value="#FF2B2B2B" />
             </Style>
 
         </ResourceDictionary>
@@ -70,6 +108,10 @@
             <SolidColorBrush x:Key="ExtendedSplashBackground" Color="Black" />
             <SolidColorBrush x:Key="ExtendedSplashForeground" Color="White" />
             <SolidColorBrush x:Key="ModalBackground" Color="Black" />
+
+            <Style BasedOn="{StaticResource ResizerStyle}" TargetType="controls:Resizer">
+                <Setter Property="GrabberBrush" Value="Black" />
+            </Style>
 
             <Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
                 <Setter Property="HamburgerBackground" Value="Black" />
@@ -87,11 +129,8 @@
                 <Setter Property="HeaderForeground" Value="White" />
             </Style>
 
-            <Style BasedOn="{StaticResource ResizerStyle}" TargetType="controls:Resizer">
-                <Setter Property="GrabberBrush" Value="Black" />
-            </Style>
-
         </ResourceDictionary>
+
 
     </ResourceDictionary.ThemeDictionaries>
 

--- a/Templates (Project)/Minimal/ViewModels/DetailPageViewModel.cs
+++ b/Templates (Project)/Minimal/ViewModels/DetailPageViewModel.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Template10.Mvvm;
 using Template10.Services.NavigationService;
 using Windows.UI.Xaml.Navigation;
+using Windows.UI.Xaml.Media;
 
 namespace Sample.ViewModels
 {
@@ -54,5 +55,15 @@ namespace Sample.ViewModels
 
         private string _Value = "Default";
         public string Value { get { return _Value; } set { Set(ref _Value, value); } }
+
+        public Brush HeaderBackgroundBrush
+        {
+            get { return (Brush)Views.Shell.HeaderBackgroundBrush; }
+        }
+
+        public SolidColorBrush HeaderForegroundBrush
+        {
+            get { return Views.Shell.HeaderForegroundBrush; }
+        }
     }
 }

--- a/Templates (Project)/Minimal/ViewModels/MainPageViewModel.cs
+++ b/Templates (Project)/Minimal/ViewModels/MainPageViewModel.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Template10.Services.NavigationService;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
+using Windows.UI.Xaml.Media;
 
 namespace Sample.ViewModels
 {
@@ -51,6 +52,16 @@ namespace Sample.ViewModels
         public void GotoDetailsPage()
         {
             this.NavigationService.Navigate(typeof(Views.DetailPage), this.Value);
+        }
+
+        public Brush HeaderBackgroundBrush
+        {
+            get { return (Brush)Views.Shell.HeaderBackgroundBrush; }
+        }
+
+        public SolidColorBrush HeaderForegroundBrush
+        {
+            get { return Views.Shell.HeaderForegroundBrush; }
         }
     }
 }

--- a/Templates (Project)/Minimal/ViewModels/SettingsPageViewModel.cs
+++ b/Templates (Project)/Minimal/ViewModels/SettingsPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 
 namespace Sample.ViewModels
 {
@@ -7,6 +8,16 @@ namespace Sample.ViewModels
     {
         public SettingsPartViewModel SettingsPartViewModel { get; } = new SettingsPartViewModel();
         public AboutPartViewModel AboutPartViewModel { get; } = new AboutPartViewModel();
+
+        public Brush HeaderBackgroundBrush
+        {
+            get { return (Brush)Views.Shell.HeaderBackgroundBrush; }
+        }
+
+        public SolidColorBrush HeaderForegroundBrush
+        {
+            get { return Views.Shell.HeaderForegroundBrush; }
+        }
     }
 
     public class SettingsPartViewModel : Mvvm.ViewModelBase

--- a/Templates (Project)/Minimal/Views/DetailPage.xaml
+++ b/Templates (Project)/Minimal/Views/DetailPage.xaml
@@ -44,7 +44,10 @@
 
         <!-- header -->
 
-        <controls:PageHeader Text="Detail Page" Frame="{x:Bind Frame}" />
+        <controls:PageHeader Frame="{x:Bind Frame, Mode=OneWay}"
+                             Text="Detail Page" 
+                             HeaderBackground="{Binding HeaderBackgroundBrush, Mode=OneTime}"
+                             HeaderForeground="{Binding HeaderForegroundBrush, Mode=OneWay}"/>
 
         <!--#region content-->
 

--- a/Templates (Project)/Minimal/Views/MainPage.xaml
+++ b/Templates (Project)/Minimal/Views/MainPage.xaml
@@ -35,7 +35,11 @@
             <RowDefinition />
         </Grid.RowDefinitions>
 
-        <controls:PageHeader BackButtonVisibility="Collapsed" Frame="{x:Bind Frame, Mode=OneWay}" Text="Main Page"/>
+        <controls:PageHeader BackButtonVisibility="Collapsed"
+                             Frame="{x:Bind Frame, Mode=OneWay}"
+                             Text="Main Page"
+                             HeaderBackground="{Binding HeaderBackgroundBrush, Mode=OneTime}"
+                             HeaderForeground="{Binding HeaderForegroundBrush, Mode=OneWay}"/>
       
         <!--  #region content  -->
         

--- a/Templates (Project)/Minimal/Views/SettingsPage.xaml
+++ b/Templates (Project)/Minimal/Views/SettingsPage.xaml
@@ -23,7 +23,11 @@
 
         <!--  header  -->
 
-        <controls:PageHeader Frame="{x:Bind Frame, Mode=OneWay}" Text="Settings Page" />
+        <controls:PageHeader Frame="{x:Bind Frame, Mode=OneWay}"
+                             Text="Settings Page" 
+                             HeaderBackground="{Binding HeaderBackgroundBrush, Mode=OneTime}"
+                             HeaderForeground="{Binding HeaderForegroundBrush, Mode=OneWay}"/>
+
 
         <!--  #region content  -->
 

--- a/Templates (Project)/Minimal/Views/Shell.xaml.cs
+++ b/Templates (Project)/Minimal/Views/Shell.xaml.cs
@@ -11,6 +11,8 @@ using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Sample.Services.SettingsServices;
+using Windows.UI.Xaml.Media;
+using System.Collections.Generic;
 
 namespace Sample.Views
 {
@@ -19,12 +21,42 @@ namespace Sample.Views
     {
         public static Shell Instance { get; set; }
 
+        public static Brush HeaderBackgroundBrush
+        {
+            get; set;
+        }
+
+        public static SolidColorBrush HeaderForegroundBrush
+        {
+            get; set;
+        }
+
+
+        // Due to many items for HamburgerMenu to be styled (8 to be exact) 
+        // a dictionary data container provides easy handling
+
+        private static Dictionary<string, SolidColorBrush> HamburgerMenuDefaultColors;
+
+        private static SolidColorBrush HamburgerBackgroundBrush;
+        private static SolidColorBrush HamburgerForegroundBrush;
+        private static SolidColorBrush NavAreaBackgroundBrush;
+        private static SolidColorBrush NavButtonBackgroundBrush;
+
+        private static SolidColorBrush NavButtonForegroundBrush;
+        private static SolidColorBrush SecondarySeparatorBrush;
+        private static SolidColorBrush NavButtonCheckedBackgroundBrush;
+        private static SolidColorBrush NavButtonCheckedForegroundBrush;
+
         public Shell(NavigationService navigationService)
         {
             Instance = this;
             InitializeComponent();
             MyHamburgerMenu.NavigationService = navigationService;
             VisualStateManager.GoToState(Instance, Instance.NormalVisualState.Name, true);
+            PopulateDefaultColors();
+            ElementTheme startupTheme = (SettingsService.Instance.AppTheme == ApplicationTheme.Light)? ElementTheme.Light : ElementTheme.Default;
+            SetThemeColors(startupTheme);
+
         }
 
         public static void SetBusyVisibility(Visibility visible, string text = null)
@@ -50,6 +82,127 @@ namespace Sample.Views
                         break;
                 }
             });
+        }
+
+        public static void SetPageHeaderTheme(PageHeader ph)
+        {
+            BootStrapper.Current.NavigationService.Dispatcher.Dispatch(() =>
+            {
+                ph.HeaderBackground = HeaderBackgroundBrush;
+                ph.HeaderForeground = HeaderForegroundBrush;
+            });
+        }
+
+        public static void SetThemeColors(ElementTheme theme)
+        {
+            WindowWrapper.Current().Dispatcher.Dispatch(() =>
+            {
+
+                Instance.RequestedTheme = theme;
+                ParseStyleforThemes(theme);
+
+                Instance.MyHamburgerMenu.HamburgerBackground = HamburgerBackgroundBrush;
+                Instance.MyHamburgerMenu.HamburgerForeground = HamburgerForegroundBrush;
+                Instance.MyHamburgerMenu.NavAreaBackground = NavAreaBackgroundBrush;
+                Instance.MyHamburgerMenu.NavButtonBackground = NavButtonBackgroundBrush;
+                Instance.MyHamburgerMenu.NavButtonForeground = NavButtonForegroundBrush;
+                Instance.MyHamburgerMenu.SecondarySeparator = SecondarySeparatorBrush;
+                Instance.MyHamburgerMenu.NavButtonCheckedBackground = NavButtonCheckedBackgroundBrush;
+                Instance.MyHamburgerMenu.NavButtonCheckedForeground = NavButtonCheckedForegroundBrush;
+
+                BootStrapper.Current.NavigationService.Refresh();
+            });
+        }
+
+        private static void ParseStyleforThemes(ElementTheme theme)
+        {
+            string ThemeColor = (theme == ElementTheme.Light) ? nameof(ElementTheme.Light) : nameof(ElementTheme.Default);
+
+            try
+            {
+                var myResourceDictionary = new ResourceDictionary();
+                myResourceDictionary.Source = new Uri("ms-appx:///Styles/Custom.xaml", UriKind.RelativeOrAbsolute);
+                 ResourceDictionary themeResource = myResourceDictionary.ThemeDictionaries[ThemeColor] as ResourceDictionary;
+                Style PageHeaderThemeStyle = themeResource[typeof(PageHeader)] as Style;
+
+                var styleQuery = (from item in PageHeaderThemeStyle.Setters.Cast<Setter>().Where(item => item.Property == PageHeader.HeaderBackgroundProperty) select item).SingleOrDefault();
+                HeaderBackgroundBrush = styleQuery.Value as Brush;
+
+                styleQuery = (from item in PageHeaderThemeStyle.Setters.Cast<Setter>().Where(item => item.Property == PageHeader.HeaderForegroundProperty) select item).SingleOrDefault();
+                HeaderForegroundBrush = styleQuery.Value as SolidColorBrush;
+
+                Style HamburgerMenuStyle = themeResource[typeof(HamburgerMenu)] as Style;
+
+                HamburgerBackgroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.HamburgerBackgroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+                HamburgerForegroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.HamburgerForegroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+                NavAreaBackgroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavAreaBackgroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+                NavButtonBackgroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavButtonBackgroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+
+                NavButtonForegroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavButtonForegroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+                SecondarySeparatorBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.SecondarySeparatorProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+                NavButtonCheckedBackgroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavButtonCheckedBackgroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+                NavButtonCheckedForegroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavButtonCheckedForegroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+            }
+            catch
+            {
+                // hard-wired defaults will take care of this!
+
+            }
+
+            // We are defensive against missing style colors (ie, null values) just in case the Custom.xaml style file is messed up,
+            // so we pick up hard-wired defaults if a value is missing.
+
+            HamburgerBackgroundBrush = HamburgerBackgroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerBackgroundBrush)];
+            HamburgerForegroundBrush = HamburgerForegroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerForegroundBrush)];
+            NavAreaBackgroundBrush = NavAreaBackgroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavAreaBackgroundBrush)];
+            NavButtonBackgroundBrush = NavButtonBackgroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonBackgroundBrush)];
+
+            NavButtonForegroundBrush = NavButtonForegroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonForegroundBrush)];
+            SecondarySeparatorBrush = SecondarySeparatorBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(SecondarySeparatorBrush)];
+            NavButtonCheckedBackgroundBrush = NavButtonCheckedBackgroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedBackgroundBrush)];
+            NavButtonCheckedForegroundBrush = NavButtonCheckedForegroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedForegroundBrush)];
+
+            // If the style brush for PageHeader is missing (null value) better use a hard-wired default
+
+            if (theme == ElementTheme.Light)
+            {
+                HeaderBackgroundBrush = HeaderBackgroundBrush ?? new SolidColorBrush(Colors.WhiteSmoke);
+                HeaderForegroundBrush = HeaderForegroundBrush ?? new SolidColorBrush(Color.FromArgb(0xff, 0x2b, 0x2b, 0x2b));
+            }else
+            {
+                HeaderBackgroundBrush = HeaderBackgroundBrush ?? new SolidColorBrush(Colors.Gainsboro);
+                HeaderForegroundBrush = HeaderForegroundBrush ?? new SolidColorBrush(Color.FromArgb(0xff, 0x2b, 0x2b, 0x2b));
+            }
+        }
+
+        private void PopulateDefaultColors()
+        {
+            HamburgerMenuDefaultColors = new Dictionary<string, SolidColorBrush>();
+
+            string ThemeColor = nameof(ElementTheme.Light);
+
+            HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerBackgroundBrush)] = new SolidColorBrush(Colors.Gainsboro);
+            HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerForegroundBrush)] = new SolidColorBrush(Colors.Black);
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavAreaBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0xf2, 0xf2, 0xf2));
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonBackgroundBrush)] = new SolidColorBrush(Colors.PowderBlue);
+
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonForegroundBrush)] = new SolidColorBrush(Colors.Black);
+            HamburgerMenuDefaultColors[ThemeColor + nameof(SecondarySeparatorBrush)] = new SolidColorBrush(Colors.Gray);
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedBackgroundBrush)] = new SolidColorBrush(Colors.PowderBlue);
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedForegroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0xcc, 0xe3, 0xf5));
+
+            ThemeColor = nameof(ElementTheme.Default);
+
+            HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0xd1, 0x34, 0x38));
+            HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerForegroundBrush)] = new SolidColorBrush(Colors.White);
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavAreaBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0x2b, 0x2b, 0x2b));
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0xd1, 0x34, 0x38));
+
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonForegroundBrush)] = new SolidColorBrush(Colors.White);
+            HamburgerMenuDefaultColors[ThemeColor + nameof(SecondarySeparatorBrush)] = new SolidColorBrush(Colors.Gray);
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0x7d, 0x1f, 0x22));
+            HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedForegroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0x43, 0x43, 0x43));
+  
         }
     }
 }


### PR DESCRIPTION
PageHeader theme binding fixed and defaults changed; theme switching enhanced in Minimal template.

You'll note that from the outset PageHeader background was defined as Brush rather than SolidColorBrush, which means you have additional options such as LinearGradientBrush, RadialGradientBrush and ImageBrush to play with for more appealing PageHeader backgrounds (haven't thought much about  DrawingBrush and VisualBrush brushes but nothing stops you from trying out by defining in Custom.xaml style file). With this PR, I have included a LinearGradientBrush for Light Theme just to demo a different background brush.

PageHeader theme switching requires each page to update itself by reading updated background/foreground values in Shell properties (thru binding in respective viewmodel. Is there an automagic way that would force all instances of PageHeader to update globally without each page updating itself? Theme-aware usercontrol? Will PropertyMetadata PropertyChangedCallBack do such a trick? Haven't given much thought here and stopped myself digressing.

Theme switching (Dark/Light) while for FrameWorkElements is a single line code --  by setting the RequestedTheme property (in this case via Shell instance); for HamburgerMenu or PageHeader, on the other hand, it requires getting user defined values from Custom.xaml and apply to individual items. If there is a more elegant way of parsing user themes (perhaps new to Windows 10 which I've overlooked?) please let me know. An ideal scenario is whereby Windows somehow cooks Custom.xaml resources that leads to an object providing easy access to Dark, Light, Default resources by theme category ... but haven't seen one. (I mean if you can do better than parsing with what XAML provides with ResourceDictionary.ThemeDictionaries).
