### PR TITLE
PageHeader background changed to Brush; HamburgerMenu Light/Dark them…

### DIFF
--- a/Template10 (Library)/Controls/PageHeader.cs
+++ b/Template10 (Library)/Controls/PageHeader.cs
@@ -199,17 +199,14 @@ namespace Template10.Controls
             DependencyProperty.Register(nameof(VisualStateNormalMinWidth), typeof(double), typeof(PageHeader), new PropertyMetadata(default(double)));
 
 
-
-        public SolidColorBrush HeaderBackgroundBrush
+        public Brush HeaderBackgroundBrush
         {
-            get { return (SolidColorBrush)GetValue(HeaderBackgroundBrushProperty); }
+            get { return (Brush)GetValue(HeaderBackgroundBrushProperty) as Brush; }
             set { SetValue(HeaderBackgroundBrushProperty, value); }
         }
 
         public static readonly DependencyProperty HeaderBackgroundBrushProperty =
-            DependencyProperty.Register(nameof(HeaderBackgroundBrush), typeof(SolidColorBrush), typeof(PageHeader), new PropertyMetadata(default(SolidColorBrush)));
-
-
+            DependencyProperty.Register(nameof(HeaderBackgroundBrush), typeof(Brush), typeof(PageHeader), new PropertyMetadata(default(Brush)));
 
         public SolidColorBrush HeaderForegroundBrush
         {

--- a/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
+++ b/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
@@ -21,22 +21,18 @@ namespace Sample.Services.SettingsServices
 
         public void ApplyAppTheme(ApplicationTheme value)
         {
-            Template10.Common.BootStrapper.Current.NavigationService.Dispatcher.Dispatch(() =>
+            switch (value)
             {
-                switch (value)
-                {
-                    case ApplicationTheme.Light:
-                        Views.Shell.Instance.RequestedTheme = ElementTheme.Light;
-                        break;
-                    case ApplicationTheme.Dark:
-                        Views.Shell.Instance.RequestedTheme = ElementTheme.Dark;
-                        break;
-                    default:
-                        Views.Shell.Instance.RequestedTheme = ElementTheme.Default;
-                        break;
-                }
-                Template10.Common.BootStrapper.Current.NavigationService.Refresh();
-            });
+                case ApplicationTheme.Light:
+                    Views.Shell.SetThemeColors(ElementTheme.Light);
+                    break;
+                case ApplicationTheme.Dark:
+                    Views.Shell.SetThemeColors(ElementTheme.Dark);
+                    break;
+                default:
+                    Views.Shell.SetThemeColors(ElementTheme.Default);
+                    break;
+            }
         }
 
         private void ApplyCacheMaxDuration(TimeSpan value)

--- a/Templates (Project)/Minimal/Styles/Custom.xaml
+++ b/Templates (Project)/Minimal/Styles/Custom.xaml
@@ -1,61 +1,131 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:controls="using:Template10.Controls">
-    <Color x:Key="CustomColor">OrangeRed</Color>
-    <x:Double x:Key="NarrowMinWidth">0</x:Double>
-    <x:Double x:Key="NormalMinWidth">521</x:Double>
-    <x:Double x:Key="WideMinWidth">1200</x:Double>
-    <SolidColorBrush x:Key="CustomColorBrush" Color="{StaticResource CustomColor}" />
-    <SolidColorBrush x:Key="ExtendedSplashBackground" Color="White" />
-    <SolidColorBrush x:Key="ExtendedSplashForeground" Color="{StaticResource CustomColor}" />
-    <SolidColorBrush x:Key="ModalBackground" Opacity=".5" Color="{StaticResource CustomColor}" />
-    <Style x:Key="HamburgerMenuStyle" TargetType="controls:HamburgerMenu">
-        <Setter Property="VisualStateNarrowMinWidth" Value="{StaticResource NarrowMinWidth}" />
-        <Setter Property="VisualStateNormalMinWidth" Value="{StaticResource NormalMinWidth}" />
-        <Setter Property="VisualStateWideMinWidth" Value="{StaticResource WideMinWidth}" />
-    </Style>
-    <Style TargetType="controls:PageHeader">
-        <Setter Property="VisualStateNarrowMinWidth" Value="{StaticResource NarrowMinWidth}" />
-        <Setter Property="VisualStateNormalMinWidth" Value="{StaticResource NormalMinWidth}" />
-        <Setter Property="HeaderBackgroundBrush" Value="{ThemeResource CustomHeaderBackground}" />
-        <Setter Property="HeaderForegroundBrush" Value="{ThemeResource CustomHeaderForeground}" />
-    </Style>
-    <Style TargetType="controls:Resizer">
-        <Setter Property="GrabberVisibility" Value="Visible" />
-        <Setter Property="GrabberBrush" Value="{StaticResource CustomColorBrush}"/>
-    </Style>
-    <ResourceDictionary.ThemeDictionaries>
-        <!--  RequestedTheme=Dark  -->
-        <ResourceDictionary x:Key="Dark">
-            <SolidColorBrush x:Key="CustomHeaderBackground" Color="Black" />
-            <SolidColorBrush x:Key="CustomHeaderForeground" Color="White" />
-            <Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
-                <Setter Property="AccentColor" Value="{StaticResource CustomColor}" />
-            </Style>
-        </ResourceDictionary>
-        <!--  RequestedTheme=Light  -->
-        <ResourceDictionary x:Key="Light">
-            <SolidColorBrush x:Key="CustomHeaderBackground" Color="WhiteSmoke" />
-            <SolidColorBrush x:Key="CustomHeaderForeground" Color="#FF2B2B2B" />
-            <Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
-                <Setter Property="AccentColor" Value="{StaticResource CustomColor}" />
-            </Style>
-        </ResourceDictionary>
-        <!--  RequestedTheme=HighContrast  -->
-        <ResourceDictionary x:Key="HighContrast">
-            <SolidColorBrush x:Key="ExtendedSplashBackground" Color="Black" />
-            <SolidColorBrush x:Key="ExtendedSplashForeground" Color="White" />
-            <SolidColorBrush x:Key="ModalBackground" Color="Black" />
-            <Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
-                <Setter Property="HamburgerBackground" Value="Black" />
-                <Setter Property="HamburgerForeground" Value="White" />
-                <Setter Property="NavAreaBackground" Value="Black" />
-                <Setter Property="NavButtonBackground" Value="White" />
-                <Setter Property="NavButtonCheckedBackground" Value="White" />
-                <Setter Property="NavButtonForeground" Value="Black" />
-                <Setter Property="NavButtonHoverBackground" Value="White" />
-                <Setter Property="SecondarySeparator" Value="White" />
-            </Style>
-            <SolidColorBrush x:Key="CustomHeaderBackground" Color="Black" />
-            <SolidColorBrush x:Key="CustomHeaderForeground" Color="White" />
-        </ResourceDictionary>
-    </ResourceDictionary.ThemeDictionaries>
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:controls="using:Template10.Controls">
+	
+	<Color x:Key="CustomColor">OrangeRed</Color>
+	<x:Double x:Key="NarrowMinWidth">0</x:Double>
+	<x:Double x:Key="NormalMinWidth">521</x:Double>
+	<x:Double x:Key="WideMinWidth">1200</x:Double>
+	
+	<SolidColorBrush x:Key="CustomColorBrush" Color="{StaticResource CustomColor}" />
+	<SolidColorBrush x:Key="ExtendedSplashBackground" Color="White" />
+	<SolidColorBrush x:Key="ExtendedSplashForeground" Color="{StaticResource CustomColor}" />
+	<SolidColorBrush x:Key="ModalBackground" Opacity=".5" Color="{StaticResource CustomColor}" />
+
+	<Style x:Key="HamburgerMenuStyle" TargetType="controls:HamburgerMenu">
+		<Setter Property="VisualStateNarrowMinWidth" Value="{StaticResource NarrowMinWidth}" />
+		<Setter Property="VisualStateNormalMinWidth" Value="{StaticResource NormalMinWidth}" />
+		<Setter Property="VisualStateWideMinWidth" Value="{StaticResource WideMinWidth}" />
+	</Style>
+	
+	<Style TargetType="controls:PageHeader">
+		<Setter Property="VisualStateNarrowMinWidth" Value="{StaticResource NarrowMinWidth}" />
+		<Setter Property="VisualStateNormalMinWidth" Value="{StaticResource NormalMinWidth}" />
+		<Setter Property="HeaderBackgroundBrush" Value="{ThemeResource CustomHeaderBackground}" />
+		<Setter Property="HeaderForegroundBrush" Value="{ThemeResource CustomHeaderForeground}" />
+	</Style>
+	
+	<Style TargetType="controls:Resizer">
+		<Setter Property="GrabberVisibility" Value="Visible" />
+		<Setter Property="GrabberBrush" Value="{StaticResource CustomColorBrush}"/>
+	</Style>
+	
+	<ResourceDictionary.ThemeDictionaries>
+		
+		<!--  RequestedTheme=Dark  -->
+		
+		<ResourceDictionary x:Key="Default">
+
+			<Brush x:Key="CustomHeaderBackground">Gainsboro</Brush>
+			<SolidColorBrush x:Key="CustomHeaderForeground" Color="#FF2B2B2B" />
+
+			<SolidColorBrush x:Key="PageHeaderBackground" Color="Gainsboro" />
+			<SolidColorBrush x:Key="PageHeaderForeground" Color="#FF2B2B2B" />
+
+			<Style BasedOn="{StaticResource ResizerStyle}" TargetType="controls:Resizer">
+				<Setter Property="GrabberBrush" Value="{StaticResource CustomColorBrush}" />
+			</Style>
+
+			<Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
+				<Setter Property="AccentColor" Value="{StaticResource CustomColor}" />
+				<Setter Property="HamburgerForeground" Value="White" />
+				<Setter Property="HamburgerBackground" Value="#FFD13438" />
+				<Setter Property="NavButtonForeground" Value="White" />
+				<Setter Property="NavButtonBackground" Value="#FF2B2B2B" />
+				<Setter Property="NavAreaBackground" Value="#FF2B2B2B" />
+				<Setter Property="NavButtonCheckedBackground" Value="#FF7D1F22" />
+				<Setter Property="NavButtonHoverBackground" Value="SlateGray" />
+				<Setter Property="SecondarySeparator" Value="Gray" />
+			</Style>
+		</ResourceDictionary>
+		
+		<!--  RequestedTheme=Light  -->
+		
+		<ResourceDictionary x:Key="Light">
+
+			<SolidColorBrush x:Key="ExtendedSplashBackground" Color="White" />
+			<SolidColorBrush x:Key="ExtendedSplashForeground" Color="DimGray" />
+			<SolidColorBrush x:Key="ModalBackground" Opacity=".5" Color="{ThemeResource SystemAccentColor}" />
+
+			<LinearGradientBrush  x:Key="CustomHeaderBackground" StartPoint="0,0" EndPoint="1,0">
+				<GradientBrush.GradientStops>
+					<GradientStopCollection>
+						<GradientStop Color="Gainsboro" Offset="0" />
+						<GradientStop Color="WhiteSmoke" Offset="0.5" />
+						<GradientStop Color="transparent" Offset="1" />
+					</GradientStopCollection>
+				</GradientBrush.GradientStops>
+			</LinearGradientBrush>
+			<SolidColorBrush x:Key="CustomHeaderForeground" Color="#FF2B2B2B" />
+			
+			<SolidColorBrush x:Key="PageHeaderBackground" Color="WhiteSmoke" />
+			<SolidColorBrush x:Key="PageHeaderForeground" Color="#FF2B2B2B" />
+
+			<Style BasedOn="{StaticResource ResizerStyle}" TargetType="controls:Resizer">
+				<Setter Property="GrabberBrush" Value="{StaticResource CustomColorBrush}" />
+			</Style>
+
+			<Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
+				<Setter Property="AccentColor" Value="{StaticResource CustomColor}" />
+				<Setter Property="HamburgerForeground" Value="Black" />
+				<Setter Property="HamburgerBackground" Value="Silver"/>
+				<Setter Property="NavButtonForeground" Value="Black" />
+				<Setter Property="NavButtonBackground" Value="#FFF2F2F2" />
+				<Setter Property="NavAreaBackground" Value="#FFF2F2F2" />
+				<Setter Property="NavButtonCheckedBackground" Value="PowderBlue" />
+				<Setter Property="NavButtonHoverBackground" Value="LightSteelBlue" />
+				<Setter Property="SecondarySeparator" Value="Gray" />
+			</Style>
+		</ResourceDictionary>
+		
+		<!--  RequestedTheme=HighContrast  -->
+		
+		<ResourceDictionary x:Key="HighContrast">
+			<SolidColorBrush x:Key="ExtendedSplashBackground" Color="Black" />
+			<SolidColorBrush x:Key="ExtendedSplashForeground" Color="White" />
+			<SolidColorBrush x:Key="ModalBackground" Color="Black" />
+
+			<SolidColorBrush x:Key="CustomHeaderBackground" Color="Black" />
+			<SolidColorBrush x:Key="CustomHeaderForeground" Color="White" />
+
+			<SolidColorBrush x:Key="PageHeaderBackground" Color="Black" />
+			<SolidColorBrush x:Key="PageHeaderForeground" Color="White" />
+			
+			<Style BasedOn="{StaticResource ResizerStyle}" TargetType="controls:Resizer">
+				<Setter Property="GrabberBrush" Value="Black" />
+			</Style>
+
+			<Style BasedOn="{StaticResource HamburgerMenuStyle}" TargetType="controls:HamburgerMenu">
+				<Setter Property="HamburgerForeground" Value="White" />
+				<Setter Property="HamburgerBackground" Value="Black" />
+				<Setter Property="NavButtonForeground" Value="Black" />
+				<Setter Property="NavButtonBackground" Value="White" />
+				<Setter Property="NavAreaBackground" Value="Black" />
+				<Setter Property="NavButtonCheckedBackground" Value="White" />
+				<Setter Property="NavButtonHoverBackground" Value="White" />
+				<Setter Property="SecondarySeparator" Value="White" />
+			</Style>
+
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/Templates (Project)/Minimal/Views/Shell.xaml.cs
+++ b/Templates (Project)/Minimal/Views/Shell.xaml.cs
@@ -11,45 +11,164 @@ using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Sample.Services.SettingsServices;
+using System.Collections.Generic;
+using Windows.UI.Xaml.Media;
 
 namespace Sample.Views
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-SplitView
-    public sealed partial class Shell : Page
-    {
-        public static Shell Instance { get; set; }
+	// DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-SplitView
+	public sealed partial class Shell : Page
+	{
+		public static Shell Instance { get; set; }
 
-        public Shell(NavigationService navigationService)
-        {
-            Instance = this;
-            InitializeComponent();
-            MyHamburgerMenu.NavigationService = navigationService;
-            VisualStateManager.GoToState(Instance, Instance.NormalVisualState.Name, true);
-        }
+		// Due to many items for HamburgerMenu to be styled (8 to be exact) 
+		// a dictionary data container provides easy handling
 
-        public static void SetBusyVisibility(Visibility visible, string text = null)
-        {
-            WindowWrapper.Current().Dispatcher.Dispatch(() =>
-            {
-                switch (visible)
-                {
-                    case Visibility.Visible:
-                        Instance.FindName(nameof(BusyScreen));
-                        Instance.BusyText.Text = text ?? string.Empty;
-                        if (VisualStateManager.GoToState(Instance, Instance.BusyVisualState.Name, true))
-                        {
-                            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
-                                AppViewBackButtonVisibility.Collapsed;
-                        }
-                        break;
-                    case Visibility.Collapsed:
-                        if (VisualStateManager.GoToState(Instance, Instance.NormalVisualState.Name, true))
-                        {
-                            BootStrapper.Current.UpdateShellBackButton();
-                        }
-                        break;
-                }
-            });
-        }
-    }
+		private static Dictionary<string, SolidColorBrush> HamburgerMenuDefaultColors;
+
+		private static SolidColorBrush HamburgerBackgroundBrush;
+		private static SolidColorBrush HamburgerForegroundBrush;
+		private static SolidColorBrush NavAreaBackgroundBrush;
+		private static SolidColorBrush NavButtonBackgroundBrush;
+
+		private static SolidColorBrush NavButtonForegroundBrush;
+		private static SolidColorBrush SecondarySeparatorBrush;
+		private static SolidColorBrush NavButtonCheckedBackgroundBrush;
+		private static SolidColorBrush NavButtonCheckedForegroundBrush;
+		private static SolidColorBrush NavButtonHoverBackgroundBrush;
+
+		public Shell(NavigationService navigationService)
+		{
+			Instance = this;
+			InitializeComponent();
+			MyHamburgerMenu.NavigationService = navigationService;
+			VisualStateManager.GoToState(Instance, Instance.NormalVisualState.Name, true);
+			PopulateDefaultColors();
+			ElementTheme startupTheme = (SettingsService.Instance.AppTheme == ApplicationTheme.Light)? ElementTheme.Light : ElementTheme.Default;
+			SetThemeColors(startupTheme);
+		}
+
+		public static void SetBusyVisibility(Visibility visible, string text = null)
+		{
+			WindowWrapper.Current().Dispatcher.Dispatch(() =>
+			{
+				switch (visible)
+				{
+					case Visibility.Visible:
+						Instance.FindName(nameof(BusyScreen));
+						Instance.BusyText.Text = text ?? string.Empty;
+						if (VisualStateManager.GoToState(Instance, Instance.BusyVisualState.Name, true))
+						{
+							SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
+								AppViewBackButtonVisibility.Collapsed;
+						}
+						break;
+					case Visibility.Collapsed:
+						if (VisualStateManager.GoToState(Instance, Instance.NormalVisualState.Name, true))
+						{
+							BootStrapper.Current.UpdateShellBackButton();
+						}
+						break;
+				}
+			});
+		}
+
+		public static void SetThemeColors(ElementTheme theme)
+		{
+
+			WindowWrapper.Current().Dispatcher.Dispatch(() =>
+			{
+
+				Instance.RequestedTheme = theme;
+				ParseStyleforThemes(theme);
+
+				Instance.MyHamburgerMenu.HamburgerBackground = HamburgerBackgroundBrush;
+				Instance.MyHamburgerMenu.HamburgerForeground = HamburgerForegroundBrush;
+				Instance.MyHamburgerMenu.NavAreaBackground = NavAreaBackgroundBrush;
+				Instance.MyHamburgerMenu.NavButtonBackground = NavButtonBackgroundBrush;
+				Instance.MyHamburgerMenu.NavButtonForeground = NavButtonForegroundBrush;
+				Instance.MyHamburgerMenu.SecondarySeparator = SecondarySeparatorBrush;
+				Instance.MyHamburgerMenu.NavButtonCheckedBackground = NavButtonCheckedBackgroundBrush;
+				Instance.MyHamburgerMenu.NavButtonCheckedForeground = NavButtonCheckedForegroundBrush;
+				Instance.MyHamburgerMenu.NavButtonHoverBackground = NavButtonHoverBackgroundBrush;
+
+				BootStrapper.Current.NavigationService.Refresh();
+			});
+		}
+
+		private static void ParseStyleforThemes(ElementTheme theme)
+		{
+			string ThemeColor = (theme == ElementTheme.Light) ? nameof(ElementTheme.Light) : nameof(ElementTheme.Default);
+
+			try
+			{
+				var myResourceDictionary = new ResourceDictionary();
+				myResourceDictionary.Source = new Uri("ms-appx:///Styles/Custom.xaml", UriKind.RelativeOrAbsolute);
+				ResourceDictionary themeResource = myResourceDictionary.ThemeDictionaries[ThemeColor] as ResourceDictionary;
+
+				Style HamburgerMenuStyle = themeResource[typeof(HamburgerMenu)] as Style;
+
+				HamburgerBackgroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.HamburgerBackgroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+				HamburgerForegroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.HamburgerForegroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+				NavAreaBackgroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavAreaBackgroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+				NavButtonBackgroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavButtonBackgroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+
+				NavButtonForegroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavButtonForegroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+				SecondarySeparatorBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.SecondarySeparatorProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+				NavButtonCheckedBackgroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavButtonCheckedBackgroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+				NavButtonCheckedForegroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavButtonCheckedForegroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+				NavButtonHoverBackgroundBrush = ((from item in HamburgerMenuStyle.Setters.Cast<Setter>().Where(item => item.Property == HamburgerMenu.NavButtonHoverBackgroundProperty) select item).SingleOrDefault())?.Value as SolidColorBrush;
+			}
+			catch
+			{
+				// defaults picked up in PopulateDefaultColors() will take care of this!
+			}
+
+			// We are defensive against missing style colors (ie, null values) just in case the Custom.xaml style file is messed up,
+			// so we pick up hard-wired defaults if a value is missing.
+
+			HamburgerBackgroundBrush = HamburgerBackgroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerBackgroundBrush)];
+			HamburgerForegroundBrush = HamburgerForegroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerForegroundBrush)];
+			NavAreaBackgroundBrush = NavAreaBackgroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavAreaBackgroundBrush)];
+			NavButtonBackgroundBrush = NavButtonBackgroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonBackgroundBrush)];
+
+			NavButtonForegroundBrush = NavButtonForegroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonForegroundBrush)];
+			SecondarySeparatorBrush = SecondarySeparatorBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(SecondarySeparatorBrush)];
+			NavButtonCheckedBackgroundBrush = NavButtonCheckedBackgroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedBackgroundBrush)];
+			NavButtonCheckedForegroundBrush = NavButtonCheckedForegroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedForegroundBrush)];
+			NavButtonHoverBackgroundBrush = NavButtonHoverBackgroundBrush ?? HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonHoverBackgroundBrush)];
+		}
+
+		private void PopulateDefaultColors()
+		{
+			HamburgerMenuDefaultColors = new Dictionary<string, SolidColorBrush>();
+
+			string ThemeColor = nameof(ElementTheme.Light);
+
+			HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerBackgroundBrush)] = new SolidColorBrush(Colors.Gainsboro);
+			HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerForegroundBrush)] = new SolidColorBrush(Colors.Black);
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavAreaBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0xf2, 0xf2, 0xf2));
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0xf2, 0xf2, 0xf2));
+
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonForegroundBrush)] = new SolidColorBrush(Colors.Black);
+			HamburgerMenuDefaultColors[ThemeColor + nameof(SecondarySeparatorBrush)] = new SolidColorBrush(Colors.Gray);
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedBackgroundBrush)] = new SolidColorBrush(Colors.PowderBlue);
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedForegroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0xcc, 0xe3, 0xf5));
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonHoverBackgroundBrush)] = new SolidColorBrush(Colors.LightSteelBlue);
+
+			ThemeColor = nameof(ElementTheme.Default);
+
+			HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0xd1, 0x34, 0x38));
+			HamburgerMenuDefaultColors[ThemeColor + nameof(HamburgerForegroundBrush)] = new SolidColorBrush(Colors.White);
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavAreaBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0x2b, 0x2b, 0x2b));
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0x2b, 0x2b, 0x2b));
+
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonForegroundBrush)] = new SolidColorBrush(Colors.White);
+			HamburgerMenuDefaultColors[ThemeColor + nameof(SecondarySeparatorBrush)] = new SolidColorBrush(Colors.Gray);
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedBackgroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0x7d, 0x1f, 0x22));
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonCheckedForegroundBrush)] = new SolidColorBrush(Color.FromArgb(0xff, 0x43, 0x43, 0x43));
+			HamburgerMenuDefaultColors[ThemeColor + nameof(NavButtonHoverBackgroundBrush)] = new SolidColorBrush(Colors.SlateGray);
+
+		}
+	}
 }


### PR DESCRIPTION
A good idea to have PageHeader background as Brush for more flexibility to use various brushes including images (it was from the outset anyway but changed midway); HamburgerMenu Light/Dark themes work without touching the UserControl (i.e., no radical alteration as for PageHeader yet) and Custom.xaml tweaked to demo Dark/Light themes.
HighContrast needs some corrections to be made (not included in this PR); for instance, NavButtonCheckedForeground although defined in code-behind is not bound in XAML and it would be necessary to define NavButtonHoverForeground to allow a high contrast hover.
