### PR TITLE
CotentControl's name "NormalFore" reference still exists in menu Disabled VisualState ...

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -154,7 +154,7 @@
                                             <Rectangle x:Name="PressedBack" Fill="{Binding NavButtonPressedBackground, ElementName=ThisPage}" IsHitTestVisible="False" Visibility="Collapsed"/>
                                             <Rectangle x:Name="HoverBack" Fill="{Binding NavButtonHoverBackground, ElementName=ThisPage}" IsHitTestVisible="False" Visibility="Collapsed"/>
                                             <Rectangle x:Name="CheckedBack" Fill="{Binding NavButtonCheckedBackground, ElementName=ThisPage}" IsHitTestVisible="False" Visibility="Collapsed"/>
-                                            <ContentControl Content="{TemplateBinding Content}" Foreground="{Binding NavButtonForeground, ElementName=ThisPage, FallbackValue=White}" IsHitTestVisible="False" />
+                                            <ContentControl x:Name="NormalFore" Content="{TemplateBinding Content}" Foreground="{Binding NavButtonForeground, ElementName=ThisPage, FallbackValue=White}" IsHitTestVisible="False" />
                                         </Grid>
                                     </ControlTemplate>
                                 </ToggleButton.Template>


### PR DESCRIPTION
You'll notice this problem only if you disable a menu item (IsEnabled = false for the TextBlock in  Controls:HamburgerButtonInfo). ContentControl's name  "NormalFore" has been removed in the last commit but a reference to it still exists for HamburgerMenu Disabled VisualState. If you happen to be disabling a menu item(s), which I am doing, the app will crash. In my case, I have some privileged menu items that stay disabled until the user logs in. Having a disabled menu with a distinct disabled status (currently opacity changed to 0.5) is therefore a cool thing.

Question for Jerry:
The styling code is now consolidated into the T10 library which keeps things tidy. What is not clear to me however is the preferred usage mode for custom styles in Custom.xaml?
I understand a developer can still do whatever to customize (as I did in Shell.xaml.cs) but appreciate your thinking behind the usage for Custom.xaml as well as the AccentColor. Perhaps this discussion may feed into a documentation on this very topic??
