### PR TITLE
Addresses issue in #163 regardng Page.BottomAppBar. May not be a perfe…

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -168,6 +168,10 @@
     </UserControl.Resources>
 
     <Grid x:Name="RootGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="VisualStateGroup">
@@ -220,6 +224,37 @@
                 </VisualState>
 
             </VisualStateGroup>
+
+            <VisualStateGroup x:Name="BottomAppBarPushStates">
+                <VisualState
+                x:Name="BottomAppBarExists">
+                    <Storyboard>
+                        <DoubleAnimation EnableDependentAnimation="True"
+                        Storyboard.TargetName="BottomAppBarAdjust"
+                        Storyboard.TargetProperty="Height"
+                        To="20.0"
+                        Duration="0:0:0.2">
+                            <DoubleAnimation.EasingFunction>
+                                <CubicEase EasingMode="EaseOut" />
+                            </DoubleAnimation.EasingFunction>
+                        </DoubleAnimation>
+                    </Storyboard>
+                </VisualState>
+                <VisualState
+                x:Name="BottomAppBarNone">
+                    <Storyboard>
+                        <DoubleAnimation EnableDependentAnimation="True"
+                        Storyboard.TargetName="BottomAppBarAdjust"
+                        Storyboard.TargetProperty="Height"
+                        To="0.0"
+                        Duration="0:0:0.2">
+                            <DoubleAnimation.EasingFunction>
+                                <CubicEase EasingMode="EaseOut" />
+                            </DoubleAnimation.EasingFunction>
+                        </DoubleAnimation>
+                    </Storyboard>
+                </VisualState>
+            </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
         <ContentControl Height="48" Margin="48,0,0,0"
@@ -239,7 +274,7 @@
             </Interactivity:Interaction.Behaviors>
         </ContentControl>
 
-        <SplitView x:Name="ShellSplitView" Grid.Column="0"
+        <SplitView x:Name="ShellSplitView" Grid.Column="0" Grid.Row="0"
                    DisplayMode="Inline" OpenPaneLength="220"
                    PaneBackground="Transparent">
 
@@ -252,6 +287,7 @@
 
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
@@ -349,6 +385,7 @@
                 <FontIcon FontSize="20" Glyph="&#xE700;" />
             </StackPanel>
         </Button>
+        <Rectangle x:Name="BottomAppBarAdjust" Grid.Row="1" Height="0"></Rectangle>
 
     </Grid>
 </UserControl>

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -566,5 +566,26 @@ namespace Template10.Controls
         {
             _SecondaryButtonStackPanel = sender as StackPanel;
         }
+
+        public bool PageHasBottomAppBar
+        {
+            get { return (bool)GetValue(PageHasBottomAppBarProperty); }
+            set
+            {
+                SetValue(PageHasBottomAppBarProperty, value);
+
+                if(value)
+                {
+                    VisualStateManager.GoToState(this, this.BottomAppBarExists.Name, true);
+                }else
+                {
+                    VisualStateManager.GoToState(this, this.BottomAppBarNone.Name, true);
+                }
+
+            }
+        }
+        public static readonly DependencyProperty PageHasBottomAppBarProperty =
+            DependencyProperty.Register(nameof(PageHasBottomAppBar), typeof(bool),
+                  typeof(HamburgerMenu), new PropertyMetadata(false));
     }
 }

--- a/Templates (Project)/Minimal/Minimal.csproj
+++ b/Templates (Project)/Minimal/Minimal.csproj
@@ -102,9 +102,13 @@
     <Compile Include="Services\SettingsServices\ISettingsService.cs" />
     <Compile Include="Services\SettingsServices\SettingsService.Apply.cs" />
     <Compile Include="Services\SettingsServices\SettingsService.cs" />
+    <Compile Include="ViewModels\BabPageViewModel.cs" />
     <Compile Include="ViewModels\MainPageViewModel.cs" />
     <Compile Include="ViewModels\DetailPageViewModel.cs" />
     <Compile Include="ViewModels\SettingsPageViewModel.cs" />
+    <Compile Include="Views\BabPage.xaml.cs">
+      <DependentUpon>BabPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\DetailPage.xaml.cs">
       <DependentUpon>DetailPage.xaml</DependentUpon>
     </Compile>
@@ -147,6 +151,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Page>
+    <Page Include="Views\BabPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\DetailPage.xaml">
       <SubType>Designer</SubType>

--- a/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
+++ b/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
@@ -21,7 +21,22 @@ namespace Sample.Services.SettingsServices
 
         public void ApplyAppTheme(ApplicationTheme value)
         {
-            Views.Shell.HamburgerMenu.RefreshStyles(value);
+            Template10.Common.WindowWrapper.Current().Dispatcher.Dispatch(() =>
+            {
+                switch (value)
+                {
+                    case ApplicationTheme.Light:
+                        Views.Shell.Instance.RequestedTheme = ElementTheme.Light;
+                        break;
+                    case ApplicationTheme.Dark:
+                        Views.Shell.Instance.RequestedTheme = ElementTheme.Dark;
+                        break;
+                    default:
+                        Views.Shell.Instance.RequestedTheme = ElementTheme.Default;
+                        break;
+                }
+                Template10.Common.BootStrapper.Current.NavigationService.Refresh();
+            });
         }
 
         private void ApplyCacheMaxDuration(TimeSpan value)

--- a/Templates (Project)/Minimal/ViewModels/BabPageViewModel.cs
+++ b/Templates (Project)/Minimal/ViewModels/BabPageViewModel.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Template10.Services.NavigationService;
+using Windows.UI.Popups;
+using Windows.UI.Xaml.Navigation;
+using Windows.UI.Xaml.Media;
+using Windows.ApplicationModel.Resources;
+
+namespace Sample.ViewModels
+{
+    public class BabPageViewModel : Sample.Mvvm.ViewModelBase
+    {
+
+        public BabPageViewModel()
+        {
+   
+        }
+
+        public override void OnNavigatedTo(object parameter, NavigationMode mode, IDictionary<string, object> state)
+        {
+            Views.Shell.HamburgerMenu.PageHasBottomAppBar = true;
+        }
+
+        public override void OnNavigatingFrom(NavigatingEventArgs args)
+        {
+            Views.Shell.HamburgerMenu.PageHasBottomAppBar = false;
+        }
+
+    }
+}

--- a/Templates (Project)/Minimal/Views/BabPage.xaml
+++ b/Templates (Project)/Minimal/Views/BabPage.xaml
@@ -1,0 +1,99 @@
+﻿<Page
+    x:Class="Sample.Views.BabPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Sample.Views"
+    xmlns:common="using:Sample.Common"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewmodel="using:Sample.ViewModels"
+    xmlns:controls="using:Template10.Controls"
+    xmlns:i="using:Microsoft.Xaml.Interactivity" 
+    xmlns:Behaviors="using:Template10.Behaviors" 
+    xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
+    d:DesignHeight="768"
+    d:DesignWidth="1024"
+    mc:Ignorable="d" x:Name="ThisPage">
+
+    <Page.DataContext>
+        <viewmodel:BabPageViewModel />
+    </Page.DataContext>
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+        <!-- adaptive states -->
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="VisualStateGroup">
+                <VisualState x:Name="VisualStateNarrow">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger x:Name="VisualStateNarrowTrigger" MinWindowWidth="{StaticResource NarrowMinWidth}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters />
+                </VisualState>
+                <VisualState x:Name="VisualStateNormal">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger x:Name="VisualStateNormalTrigger" MinWindowWidth="{StaticResource NormalMinWidth}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters />
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <!-- header -->
+
+        <controls:PageHeader Text="Page with BottomAppBar" Frame="{x:Bind Frame}" />
+
+        <!--#region content-->
+
+        <Grid Grid.Row="1">
+
+                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Margin="12,36">
+                    <Run Text="The page should shift up by about 20px in order to avoid being covered by BottomAppBar." />
+                    <LineBreak/>
+                    <LineBreak/>
+                    <Run Text="See the difference by navigating to the Home page and note how the Settings menu shifts." />
+                </TextBlock>
+
+        </Grid>
+
+        <!--#endregion-->
+
+    </Grid>
+    
+
+    <Page.BottomAppBar>
+
+        <AppBar>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="50*" />
+                    <ColumnDefinition Width="50*" />
+                </Grid.ColumnDefinitions>
+                <StackPanel x:Name="LeftPanel" Orientation="Horizontal" Grid.Column="0" HorizontalAlignment="Left">
+                    <AppBarButton Icon="List" Label="Example">
+                        <AppBarButton.Flyout>
+                            <MenuFlyout>
+                                <MenuFlyoutItem Text="Flyout Example 1"/>
+                                <MenuFlyoutItem Text="Flyout Example 2" />
+                            </MenuFlyout>
+                        </AppBarButton.Flyout>
+                    </AppBarButton>
+                </StackPanel>
+                <StackPanel x:Name="RightPanel" Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right">
+                    <AppBarButton Icon="Add" Label="Add" />
+                    <AppBarButton Icon="Remove" Label="Remove" />
+                    <AppBarSeparator />
+                    <AppBarButton Icon="Help" Label="Help"/>
+                </StackPanel>
+            </Grid>
+        </AppBar>
+
+    </Page.BottomAppBar>
+
+</Page>

--- a/Templates (Project)/Minimal/Views/BabPage.xaml.cs
+++ b/Templates (Project)/Minimal/Views/BabPage.xaml.cs
@@ -1,0 +1,18 @@
+﻿using Sample.ViewModels;
+using Windows.UI.Xaml.Navigation;
+using Windows.UI.Xaml.Controls;
+
+namespace Sample.Views
+{
+    public sealed partial class BabPage : Page
+    {
+        public BabPage()
+        {
+            InitializeComponent();
+            NavigationCacheMode = NavigationCacheMode.Disabled;
+        }
+
+        // strongly-typed view models enable x:bind
+        public BabPageViewModel ViewModel => DataContext as BabPageViewModel;
+    }
+}

--- a/Templates (Project)/Minimal/Views/Shell.xaml
+++ b/Templates (Project)/Minimal/Views/Shell.xaml
@@ -10,8 +10,7 @@
       xmlns:views="using:Sample.Views" x:Name="ThisPage"
       mc:Ignorable="d">
 
-    <Grid x:Name="RootGrid">
-
+    <Grid x:Name="RootGrid" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="VisualStateGroup">
                 <VisualState x:Name="NormalVisualState" />
@@ -34,6 +33,14 @@
                         <TextBlock Margin="12,0,0,0" VerticalAlignment="Center" Text="Home" />
                     </StackPanel>
                 </Controls:HamburgerButtonInfo>
+
+                <Controls:HamburgerButtonInfo PageType="views:BabPage">
+                    <StackPanel Orientation="Horizontal">
+                        <SymbolIcon Width="48" Height="48" Symbol="DockBottom" />
+                        <TextBlock Margin="12,0,0,0" VerticalAlignment="Center" Text="Bottom App Bar" />
+                    </StackPanel>
+                </Controls:HamburgerButtonInfo>
+                
             </Controls:HamburgerMenu.PrimaryButtons>
 
             <Controls:HamburgerMenu.SecondaryButtons>


### PR DESCRIPTION
First of all, Page.BottomAppBar covering the page sounds like a bug in XAML?? as a quick search online suggests this. I cannot for sure say this is the case.  Having read issue #163, I tried a workaround on my system, and it worked with the previous version of ApplyAppTheme() in SettingsService.Apply.cs (in Minimal template), but  with the current version of ApplyAppTheme() that calls RefreshStyles() some anomaly will be introduced (arising from the very solution attempted). I am making this PR just in case this leads to a perfect solution. At any rate, anyone using Page.BottomAppBar is welcome to make use of this code as it is fully working with an older version of ApplyAppTheme() in SettingsService.Apply.cs. I am yet to figure out how ApplyAppTheme() with RefreshStyles() is different and perhaps Jerry could help on this one.

The suggested solution is as follows: A DP is defined to set a boolean when a page has BottomAppBar (set true in OnNavigatedTo and false on NavigatingFrom). The DP sets a visual state that moves the SplitView up by 20px (to avoid covering by BottomAppBar) or restores to 0 if false.

There may be a smarter and more concise solution but this is what I could come up with.
I thought of if the SplitView's Pane and Content could be positioned at ease (this could solve the anomaly referred to and hence problem solved) but from the code can't see any easy way for this...

PS: A page with BottomAppBar is added to demo the suggested solution.
