### PR TITLE
Issue #228 - make BaseViewModel instances DI compliant

### DIFF
--- a/Samples/MvvmLight/Mvvm/ViewModelBase.cs
+++ b/Samples/MvvmLight/Mvvm/ViewModelBase.cs
@@ -13,12 +13,12 @@ namespace Sample.Mvvm
         public virtual void OnNavigatingFrom(Template10.Services.NavigationService.NavigatingEventArgs args) { /* nothing by default */ }
 
         [JsonIgnore]
-        public Template10.Services.NavigationService.NavigationService NavigationService { get; set; }
+        public Template10.Services.NavigationService.INavigationService NavigationService { get; set; }
 
         [JsonIgnore]
-        public Template10.Common.DispatcherWrapper Dispatcher => Template10.Common.WindowWrapper.Current(NavigationService)?.Dispatcher;
+        public Template10.Common.IDispatcherWrapper Dispatcher { get; set; }
 
         [JsonIgnore]
-        public Template10.Common.StateItems SessionState => Template10.Common.BootStrapper.Current.SessionState;
+        public Template10.Common.IStateItems SessionState { get; set; }
     }
 }

--- a/Template10 (Library)/Common/DispatcherWrapper.cs
+++ b/Template10 (Library)/Common/DispatcherWrapper.cs
@@ -8,7 +8,7 @@ using Windows.UI.Core;
 namespace Template10.Common
 {
     // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-DispatcherWrapper
-    public class DispatcherWrapper
+    public class DispatcherWrapper : IDispatcherWrapper
     {
         internal DispatcherWrapper(CoreDispatcher dispatcher)
         {

--- a/Template10 (Library)/Common/IDispatcherWrapper.cs
+++ b/Template10 (Library)/Common/IDispatcherWrapper.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Template10.Common
+{
+    public interface IDispatcherWrapper
+    {
+        void Dispatch(Action action);
+        Task DispatchAsync(Func<Task> func);
+        Task DispatchAsync(Action action);
+        Task<T> DispatchAsync<T>(Func<T> func);
+        bool HasThreadAccess();
+    }
+}

--- a/Template10 (Library)/Common/IStateItems.cs
+++ b/Template10 (Library)/Common/IStateItems.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Template10.Common
+{
+    public interface IStateItems
+    {
+        KeyValuePair<StateItemKey, object> Add(Type type, string key, object value);
+        bool Contains(object value);
+        bool Contains(Type type, string key);
+        bool Contains(Type type, string key, object value);
+        T Get<T>(string key);
+        void Remove(Type type);
+        void Remove(object value);
+        void Remove(Type type, string key);
+        bool TryGet<T>(string key, out T value);
+    }
+}

--- a/Template10 (Library)/Common/StateItems.cs
+++ b/Template10 (Library)/Common/StateItems.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Template10.Common
 {
-    public class StateItems : Dictionary<StateItemKey, Object>
+    public class StateItems : Dictionary<StateItemKey, Object>, IStateItems
     {
 
         public KeyValuePair<StateItemKey, Object> Add(Type type, string key, object value)

--- a/Template10 (Library)/Common/WindowWrapper.cs
+++ b/Template10 (Library)/Common/WindowWrapper.cs
@@ -16,7 +16,7 @@ namespace Template10.Common
         public readonly static List<WindowWrapper> ActiveWrappers = new List<WindowWrapper>();
         public static WindowWrapper Current() => ActiveWrappers.FirstOrDefault(x => x.Window == Window.Current) ?? Default();
         public static WindowWrapper Current(Window window) => ActiveWrappers.FirstOrDefault(x => x.Window == window);
-        public static WindowWrapper Current(NavigationService nav) => ActiveWrappers.FirstOrDefault(x => x.NavigationServices.Contains(nav));
+        public static WindowWrapper Current(INavigationService nav) => ActiveWrappers.FirstOrDefault(x => x.NavigationServices.Contains(nav));
 
         internal WindowWrapper(Window window)
         {

--- a/Template10 (Library)/Mvvm/ViewModelBase.cs
+++ b/Template10 (Library)/Mvvm/ViewModelBase.cs
@@ -15,10 +15,11 @@ namespace Template10.Mvvm
         public virtual void OnNavigatingFrom(Services.NavigationService.NavigatingEventArgs args) { /* nothing by default */ }
 
         [JsonIgnore]
-        public NavigationService NavigationService { get; set; }
+        public INavigationService NavigationService { get; set; }
         [JsonIgnore]
-        public DispatcherWrapper Dispatcher => Common.WindowWrapper.Current(NavigationService)?.Dispatcher;
+        public IDispatcherWrapper Dispatcher { get; set; }
         [JsonIgnore]
-        public Common.StateItems SessionState => BootStrapper.Current.SessionState;
+        public IStateItems SessionState { get; set; }
+        
     }
 }

--- a/Template10 (Library)/Services/NavigationService/INavigable.cs
+++ b/Template10 (Library)/Services/NavigationService/INavigable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Template10.Mvvm;
 using Windows.UI.Xaml.Navigation;
+using Template10.Common;
 
 namespace Template10.Services.NavigationService
 {
@@ -12,6 +13,8 @@ namespace Template10.Services.NavigationService
         void OnNavigatedTo(object parameter, NavigationMode mode, IDictionary<string, object> state);
         Task OnNavigatedFromAsync(IDictionary<string, object> state, bool suspending);
         void OnNavigatingFrom(Services.NavigationService.NavigatingEventArgs args);
-        NavigationService NavigationService { get; set; }
+        INavigationService NavigationService { get; set; }
+        IDispatcherWrapper Dispatcher { get; set; }
+        IStateItems SessionState { get; set; }
     }
 }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -110,6 +110,8 @@ namespace Template10.Services.NavigationService
                 {
                     // prepare for state load
                     dataContext.NavigationService = this;
+                    dataContext.Dispatcher = Common.WindowWrapper.Current(this)?.Dispatcher;
+                    dataContext.SessionState = BootStrapper.Current.SessionState;
                     var pageState = FrameFacade.PageStateContainer(page.GetType());
                     dataContext.OnNavigatedTo(parameter, mode, pageState);
                 }

--- a/Template10 (Library)/Template10 (Library).csproj
+++ b/Template10 (Library)/Template10 (Library).csproj
@@ -135,6 +135,8 @@
     <Compile Include="Common\BootStrapper.cs" />
     <Compile Include="Common\DispatcherWrapper.cs" />
     <Compile Include="Common\HandledEventArgs.cs" />
+    <Compile Include="Common\IDispatcherWrapper.cs" />
+    <Compile Include="Common\IStateItems.cs" />
     <Compile Include="Common\Mdl2.cs" />
     <Compile Include="Common\StateItems.cs" />
     <Compile Include="Common\StateKey.cs" />


### PR DESCRIPTION
This is a PR for issue #228 . The fundamental issue was that the BaseViewModel had 3 concrete instances that it had a dependency on - the NavigationService, the DispatcherWrapper and the StateItems dictionary.

Extracted interfaces for all 3 cases. 
Added these to INavigable
Implementations are injected in the OnNavigated() in NavigationService.

Side note - while looking at the unit tests project (temporarily removed from sln?), I see that the unit tests for the StateItems class are referring to an older definition of the class. Also, I see issues in the StateItems class implementation as well - particularly in the Remove(object value) method - will be a endless recursive call. Will put in a separate issue on that ?
