### PR TITLE
PageHeader title left margin set to 16px as per original setting for …

### DIFF
--- a/Samples/IncrementalLoading/IncrementalLoading/ViewModels/MainViewModel.cs
+++ b/Samples/IncrementalLoading/IncrementalLoading/ViewModels/MainViewModel.cs
@@ -1,5 +1,5 @@
 ﻿using Sample.Extensions;
-using Sample.Repositories;
+using Sample.Models;
 using Sample.Services.GithubService;
 using Sample.Shared;
 using System;

--- a/Template10 (Library)/Themes/Generic.xaml
+++ b/Template10 (Library)/Themes/Generic.xaml
@@ -830,6 +830,7 @@
                                 </Grid.ColumnDefinitions>
                                 <ContentControl x:Name="ContentControl" 
                                                 Grid.Column="0" 
+                                                Margin="16,0,0,0"
                                                 Height="{ThemeResource AppBarThemeCompactHeight}"
                                                 FontFamily="{TemplateBinding FontFamily}"
                                                 FontSize="{TemplateBinding FontSize}"


### PR DESCRIPTION
PageHeader title left margin is set to 16px as per original setting for PageHeader. Otherwise you'll note that the PageHeader title text touches the HamburgerMneu pane without a gap.
