### PR TITLE
A solution to Issue #246: Update HamMenu to react to Frame.Page.Botto…

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -423,5 +423,7 @@ namespace Template10.Common
                 return _PageKeys as Dictionary<T, Type>;
             return (_PageKeys = new Dictionary<T, Type>()) as Dictionary<T, Type>;
         }
+        public Controls.HamburgerMenu HamburgerMenu { get; set; }
+
     }
 }

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -168,6 +168,10 @@
     </UserControl.Resources>
 
     <Grid x:Name="RootGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="VisualStateGroup">
@@ -220,6 +224,30 @@
                 </VisualState>
 
             </VisualStateGroup>
+
+            <VisualStateGroup>
+                <VisualState
+                x:Name="BottomAppBarExists">
+
+                    <Storyboard>
+                        <ObjectAnimationUsingKeyFrames EnableDependentAnimation="True"
+                                                       Storyboard.TargetName="BottomAppBarSpacer"
+                                                       Storyboard.TargetProperty="Visibility">
+                            <DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
+                        </ObjectAnimationUsingKeyFrames>
+                    </Storyboard>
+                </VisualState>
+                <VisualState
+                x:Name="BottomAppBarNone">
+                    <Storyboard>
+                        <ObjectAnimationUsingKeyFrames EnableDependentAnimation="True"
+                                                       Storyboard.TargetName="BottomAppBarSpacer"
+                                                       Storyboard.TargetProperty="Visibility">
+                            <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed"/>
+                        </ObjectAnimationUsingKeyFrames>
+                    </Storyboard>
+                </VisualState>
+            </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
         <ContentControl Height="48" Margin="48,0,0,0"
@@ -239,7 +267,7 @@
             </Interactivity:Interaction.Behaviors>
         </ContentControl>
 
-        <SplitView x:Name="ShellSplitView" Grid.Column="0"
+        <SplitView x:Name="ShellSplitView" Grid.Column="0" Grid.Row="0"
                    DisplayMode="Inline" OpenPaneLength="220"
                    PaneBackground="Transparent">
 
@@ -252,6 +280,7 @@
 
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
@@ -349,6 +378,6 @@
                 <FontIcon FontSize="20" Glyph="&#xE700;" />
             </StackPanel>
         </Button>
-
+        <Rectangle x:Name="BottomAppBarSpacer" Grid.Row="1" Height="20" Visibility="Collapsed"/>
     </Grid>
 </UserControl>

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -566,5 +566,26 @@ namespace Template10.Controls
         {
             _SecondaryButtonStackPanel = sender as StackPanel;
         }
+
+        public bool PageHasBottomAppBar
+        {
+            get { return (bool)GetValue(PageHasBottomAppBarProperty); }
+            set
+            {
+                SetValue(PageHasBottomAppBarProperty, value);
+
+                if(value)
+                {
+                    VisualStateManager.GoToState(this, this.BottomAppBarExists.Name, true);
+                }else
+                {
+                    VisualStateManager.GoToState(this, this.BottomAppBarNone.Name, true);
+                }
+
+            }
+        }
+        public static readonly DependencyProperty PageHasBottomAppBarProperty =
+            DependencyProperty.Register(nameof(PageHasBottomAppBar), typeof(bool),
+                  typeof(HamburgerMenu), new PropertyMetadata(false));
     }
 }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -115,6 +115,17 @@ namespace Template10.Services.NavigationService
                     var pageState = FrameFacade.PageStateContainer(page.GetType());
                     dataContext.OnNavigatedTo(parameter, mode, pageState);
                 }
+
+                if (page.BottomAppBar?.Visibility == Visibility.Visible)
+                {
+                    if (BootStrapper.Current?.HamburgerMenu != null)
+                        BootStrapper.Current.HamburgerMenu.PageHasBottomAppBar = true;
+                }
+                else
+                {
+                    if (BootStrapper.Current?.HamburgerMenu != null)
+                        BootStrapper.Current.HamburgerMenu.PageHasBottomAppBar = false;
+                }
             }
         }
 

--- a/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
+++ b/Templates (Project)/Minimal/Services/SettingsServices/SettingsService.Apply.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
+using Template10.Common;
 
 namespace Sample.Services.SettingsServices
 {
@@ -11,22 +12,23 @@ namespace Sample.Services.SettingsServices
     {
         public void ApplyUseShellBackButton(bool value)
         {
-            Template10.Common.BootStrapper.Current.NavigationService.Dispatcher.Dispatch(() =>
+            BootStrapper.Current.NavigationService.Dispatcher.Dispatch(() =>
             {
-                Template10.Common.BootStrapper.Current.ShowShellBackButton = value;
-                Template10.Common.BootStrapper.Current.UpdateShellBackButton();
-                Template10.Common.BootStrapper.Current.NavigationService.Refresh();
+                BootStrapper.Current.ShowShellBackButton = value;
+                BootStrapper.Current.UpdateShellBackButton();
+                BootStrapper.Current.NavigationService.Refresh();
             });
         }
 
         public void ApplyAppTheme(ApplicationTheme value)
         {
-            Views.Shell.HamburgerMenu.RefreshStyles(value);
+            BootStrapper.Current.HamburgerMenu.RefreshStyles(value);
+
         }
 
         private void ApplyCacheMaxDuration(TimeSpan value)
         {
-            Template10.Common.BootStrapper.Current.CacheMaxDuration = value;
+            BootStrapper.Current.CacheMaxDuration = value;
         }
     }
 }

--- a/Templates (Project)/Minimal/Views/Shell.xaml
+++ b/Templates (Project)/Minimal/Views/Shell.xaml
@@ -10,7 +10,8 @@
       xmlns:views="using:Sample.Views" x:Name="ThisPage"
       mc:Ignorable="d">
 
-    <Grid x:Name="RootGrid">
+    <Grid x:Name="RootGrid" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="VisualStateGroup">

--- a/Templates (Project)/Minimal/Views/Shell.xaml.cs
+++ b/Templates (Project)/Minimal/Views/Shell.xaml.cs
@@ -20,12 +20,12 @@ namespace Sample.Views
     public sealed partial class Shell : Page
     {
         public static Shell Instance { get; set; }
-        public static HamburgerMenu HamburgerMenu { get { return Instance.MyHamburgerMenu; } }
 
         public Shell(NavigationService navigationService)
         {
             Instance = this;
             InitializeComponent();
+            BootStrapper.Current.HamburgerMenu = Instance.MyHamburgerMenu;
             MyHamburgerMenu.NavigationService = navigationService;
             VisualStateManager.GoToState(Instance, Instance.NormalVisualState.Name, true);
         }


### PR DESCRIPTION
<h3>How the solution works:</h3>

**Detection:** When a page is navigated to (detected in the navigation base class NavigationService.cs) the property page.BottomAppBar is checked for. If it's non-null && Visible, it means we have a BottomAppBar. The page.BottomAppBar?.Visibility condition sets a boolean DP PageHasBottomAppBar in HamburgerMenu accordingly.

**Operation:** The DP PageHasBottomAppBar listens for the detection boolean value as above and accordingly chooses a visual state for page.BottomAppBar existence or absence (the default state).
When page.BottomAppBar is present, the visual state makes a 20px high rectangular spacer 'Visible' and this pushes the HamburgerMenu pane up by 20px, else the rectangular spacer collapses (to default visual state).

The developer needs to set BootStrapper.Current.HamburgerMenu to HamburgerMenu object in Shell constructor. This is already required for ApplyAppTheme() anyway and as such not an extra requirement for Minimal template except that the HamburgerMenu property is moved from Shell to BootStrapper.

**What happens if** the developer doesn't (or forgets to) set BootStrapper.Current.HamburgerMenu  property to HamburgerMenu object?
Nothing. It means if page.BottomAppBar exists, the partial covering of HamburgerMenu pane would be noticed. Transparent to the developer, it is.

I will be posting a Sample that demos page.BottomAppBar and other features of HamburgerMenu distilled from my recent PR attempts.
