### PR TITLE
Fix for issue #263: Add missing ShellSplitView.Content=null assignment

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -474,7 +474,7 @@ namespace Template10.Controls
                 if (NavigationService == null || RootGrid.Children.Contains(NavigationService.Frame))
                     return;
                 NavigationService.Frame.SetValue(Grid.ColumnProperty, 0);
-				ShellSplitView.Content = null;
+                ShellSplitView.Content = null;
                 NavigationService.Frame.SetValue(Grid.ColumnSpanProperty, int.MaxValue);
                 NavigationService.Frame.SetValue(Grid.RowProperty, 0);
                 NavigationService.Frame.SetValue(Grid.RowSpanProperty, int.MaxValue);

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -474,6 +474,7 @@ namespace Template10.Controls
                 if (NavigationService == null || RootGrid.Children.Contains(NavigationService.Frame))
                     return;
                 NavigationService.Frame.SetValue(Grid.ColumnProperty, 0);
+				ShellSplitView.Content = null;
                 NavigationService.Frame.SetValue(Grid.ColumnSpanProperty, int.MaxValue);
                 NavigationService.Frame.SetValue(Grid.RowProperty, 0);
                 NavigationService.Frame.SetValue(Grid.RowSpanProperty, int.MaxValue);


### PR DESCRIPTION
HamburgerMenu.IsFullScreen currently crashes when full screen is activated. This happens because the NavigationService.Frame is still assigned to ShellSplitView.Content when it's added to RootGrid.Children. This causes an Exception because the control already has a parent and cannot be added to a different child control list.
