### PR TITLE
A solution to Issue #246 (Take 2): Update HamMenu to react to Frame.P…

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -168,6 +168,10 @@
     </UserControl.Resources>
 
     <Grid x:Name="RootGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="VisualStateGroup">
@@ -220,6 +224,30 @@
                 </VisualState>
 
             </VisualStateGroup>
+
+            <VisualStateGroup>
+                <VisualState
+                x:Name="IsBottomAppBarPresent">
+
+                    <Storyboard>
+                        <ObjectAnimationUsingKeyFrames EnableDependentAnimation="True"
+                                                       Storyboard.TargetName="BottomAppBarSpacer"
+                                                       Storyboard.TargetProperty="Visibility">
+                            <DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
+                        </ObjectAnimationUsingKeyFrames>
+                    </Storyboard>
+                </VisualState>
+                <VisualState
+                x:Name="IsBottomAppBarAbsent">
+                    <Storyboard>
+                        <ObjectAnimationUsingKeyFrames EnableDependentAnimation="True"
+                                                       Storyboard.TargetName="BottomAppBarSpacer"
+                                                       Storyboard.TargetProperty="Visibility">
+                            <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed"/>
+                        </ObjectAnimationUsingKeyFrames>
+                    </Storyboard>
+                </VisualState>
+            </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
         <ContentControl Height="48" Margin="48,0,0,0"
@@ -239,7 +267,7 @@
             </Interactivity:Interaction.Behaviors>
         </ContentControl>
 
-        <SplitView x:Name="ShellSplitView" Grid.Column="0"
+        <SplitView x:Name="ShellSplitView" Grid.Column="0" Grid.Row="0"
                    DisplayMode="Inline" OpenPaneLength="220"
                    PaneBackground="Transparent">
 
@@ -252,6 +280,7 @@
 
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
@@ -349,6 +378,6 @@
                 <FontIcon FontSize="20" Glyph="&#xE700;" />
             </StackPanel>
         </Button>
-
+        <Rectangle x:Name="BottomAppBarSpacer" Grid.Row="1" Height="20" Visibility="Collapsed"/>
     </Grid>
 </UserControl>

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -67,11 +67,26 @@ namespace Template10.Controls
 
         public void HighlightCorrectButton(Type pageType = null, object pageParam = null)
         {
+            bool isNavigated = (pageType != null);
+
             pageType = pageType ?? NavigationService.CurrentPageType;
             pageParam = pageParam ?? NavigationService.CurrentPageParam;
             var values = _navButtons.Select(x => x.Value);
             var button = values.FirstOrDefault(x => x.PageType == pageType && x.PageParameter == pageParam);
             Selected = button;
+
+            if (isNavigated)
+            {
+                var page = NavigationService.FrameFacade.Content as Page;
+                if (page?.BottomAppBar?.Visibility == Visibility.Visible)
+                {
+                    VisualStateManager.GoToState(this, this.IsBottomAppBarPresent.Name, true);
+                 }else
+                {
+                    VisualStateManager.GoToState(this, this.IsBottomAppBarAbsent.Name, true);
+                }
+            }
+
         }
 
         #region commands


### PR DESCRIPTION
This is a revised solution of PR #260 with code now confined to HamburgerMenu (see background info on this in PR #260).

More insight into `HamburgerMenu` code reveals that what was done previously with `NavigationService` (in NavigationService.cs) and DP in `HamburgerMenu` could actually be done by subscribing to the `NavigationService.FrameFacade.Navigated` event within `HamburgerMenu`; this only required tapping into `HighlightCorrectButton()` event handler which is already a subscriber.

Thank you Jerry for the remark in PR #260 - because of that now I am getting to know the innards of `HamburgerMenu`. The previous spaghetti code is now a neat minimalist single if-block in `HamburgerMenu` codebehind.
