### PR TITLE
Bugfix to allow null values with ValueWhenConverter

### DIFF
--- a/Template10 (Library)/Converters/ValueWhenConverter.cs
+++ b/Template10 (Library)/Converters/ValueWhenConverter.cs
@@ -10,7 +10,7 @@ namespace Template10.Converters
         {
             try
             {
-                if (value.Equals(When))
+                if (object.Equals(value, When))
                     return this.Value;
                 return this.Otherwise;
             }


### PR DESCRIPTION
The **ValueWhenConverter** class makes the following check:

```
if (value.Equals(When)) 
```

So, if we have a declaration like this one:

```
<converters:ValueWhenConverter x:Key="NullToVisibilityConverter" When="{x:Null}">
    <converters:ValueWhenConverter.Value>
        <Visibility>Collapsed</Visibility>
    </converters:ValueWhenConverter.Value>
    <converters:ValueWhenConverter.Otherwise>
        <Visibility>Visible</Visibility>
    </converters:ValueWhenConverter.Otherwise>
</converters:ValueWhenConverter>
```

Then the previous check will throw a _NullReferenceException_. Replacing it with 

```
if (object.Equals(value, When)) 
```

will prevent the exception.
