### PR TITLE
Adding Set and RaisePropertyChanged variations to BindableBase

### DIFF
--- a/Template10 (Library)/Mvvm/BindableBase.cs
+++ b/Template10 (Library)/Mvvm/BindableBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Windows.UI.Xaml;
 
@@ -51,8 +52,37 @@ namespace Template10.Mvvm
             //if is not null
             if (!object.Equals(handler, null))
             {
-                handler(this, new PropertyChangedEventArgs(propertyExpression.Name));
+                var propertyName = GetPropertyName(propertyExpression);
+
+                if (!object.Equals(propertyName, null))
+                {
+                    handler(this, new PropertyChangedEventArgs(propertyName));
+                }
             }
+        }
+
+        protected static string GetPropertyName<T>(Expression<Func<T>> propertyExpression)
+        {
+            if (object.Equals(propertyExpression, null))
+            {
+                throw new ArgumentNullException("propertyExpression");
+            }
+
+            var body = propertyExpression.Body as MemberExpression;
+
+            if (object.Equals(body, null))
+            {
+                throw new ArgumentException("Invalid argument", "propertyExpression");
+            }
+
+            var property = body.Member as PropertyInfo;
+
+            if (object.Equals(property, null))
+            {
+                throw new ArgumentException("Argument is not a property", "propertyExpression");
+            }
+
+            return property.Name;
         }
     }
 
@@ -102,8 +132,37 @@ namespace Template10.Mvvm
             //if is not null
             if (!object.Equals(handler, null))
             {
-                handler(this, new PropertyChangedEventArgs(propertyExpression.Name));
+                var propertyName = GetPropertyName(propertyExpression);
+
+                if (!object.Equals(propertyName, null))
+                {
+                    handler(this, new PropertyChangedEventArgs(propertyName));
+                }
             }
+        }
+
+        protected static string GetPropertyName<T>(Expression<Func<T>> propertyExpression)
+        {
+            if (object.Equals(propertyExpression, null))
+            {
+                throw new ArgumentNullException("propertyExpression");
+            }
+
+            var body = propertyExpression.Body as MemberExpression;
+
+            if (object.Equals(body, null))
+            {
+                throw new ArgumentException("Invalid argument", "propertyExpression");
+            }
+
+            var property = body.Member as PropertyInfo;
+
+            if (object.Equals(property, null))
+            {
+                throw new ArgumentException("Argument is not a property", "propertyExpression");
+            }
+
+            return property.Name;
         }
     }
 }

--- a/Template10 (Library)/Mvvm/BindableBase.cs
+++ b/Template10 (Library)/Mvvm/BindableBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using Windows.UI.Xaml;
 
@@ -30,6 +31,29 @@ namespace Template10.Mvvm
             RaisePropertyChanged(propertyName);
             return true;
         }
+
+        public bool Set<T>(Expression<Func<T>> propertyExpression, ref T field, T newValue)
+        {
+            //if is equal 
+            if (object.Equals(field, newValue))
+            {
+                return false;
+            }
+
+            field = newValue;
+            RaisePropertyChanged(propertyExpression);
+            return true;
+        }
+
+        public void RaisePropertyChanged<T>(Expression<Func<T>> propertyExpression)
+        {
+            var handler = PropertyChanged;
+            //if is not null
+            if (!object.Equals(handler, null))
+            {
+                handler(this, new PropertyChangedEventArgs(propertyExpression.Name));
+            }
+        }
     }
 
     public abstract class DependencyBindableBase : DependencyObject, IBindable
@@ -57,6 +81,29 @@ namespace Template10.Mvvm
             storage = value;
             RaisePropertyChanged(propertyName);
             return true;
+        }
+
+        public bool Set<T>(Expression<Func<T>> propertyExpression, ref T field, T newValue)
+        {
+            //if is equal 
+            if (object.Equals(field, newValue))
+            {
+                return false;
+            }
+
+            field = newValue;
+            RaisePropertyChanged(propertyExpression);
+            return true;
+        }
+
+        public void RaisePropertyChanged<T>(Expression<Func<T>> propertyExpression)
+        {
+            var handler = PropertyChanged;
+            //if is not null
+            if (!object.Equals(handler, null))
+            {
+                handler(this, new PropertyChangedEventArgs(propertyExpression.Name));
+            }
         }
     }
 }


### PR DESCRIPTION
Added variations of Set and RaisePropertyChanged in the BindableBase
class so that properties written as follow can work:

``` csharp
public bool _isVisible;
public bool isVisible {
    get {
      return _isVisible;
    }
    set {
      Set(() => isVisible, ref _isVisible, value);
      RaisePropertyChanged(() => Title);
    }
}
```

This will allow developers that have used these properties to not have
to rewrite the code if they are migrating there application to
Template10 (like I am)
