### PR TITLE
Removed redundant BackRequested handling in FrameFacade.

### DIFF
--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -35,10 +35,10 @@ namespace Template10.Services.NavigationService
                 BackRequested.Invoke(this, args);
             }
 
-            if (!args.Handled && (args.Handled = this.Frame.BackStackDepth > 0))
-            {
-                GoBack();
-            }
+            //if (!args.Handled && (args.Handled = this.Frame.BackStackDepth > 0))
+            //{
+            //    GoBack();
+            //}
         }
 
         public event EventHandler<HandledEventArgs> ForwardRequested;


### PR DESCRIPTION
Handle BackRequested if args.Handled == false breaks scenarios where you have two or more inner frames and you have to handle back in different ways depending on the situation.
