### PR TITLE
Setting CurrentPageType to AssemblyQualifiedName

### DIFF
--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -204,7 +204,7 @@ namespace Template10.Services.NavigationService
                 throw new InvalidOperationException("State container is unexpectedly null");
             }
 
-            state["CurrentPageType"] = CurrentPageType.ToString();
+            state["CurrentPageType"] = CurrentPageType.AssemblyQualifiedName;
             try { state["CurrentPageParam"] = CurrentPageParam; }
             catch
             {


### PR DESCRIPTION
FrameFacade.CurrentPageType was not getting set when app returning from terminated state (line 227 in NavigationService).
state["CurrentPageType"] has to be set to CurrentPageType.AssemblyQualifiedName instead of 
CurrentPageType.ToString() to fix this.
To reproduce:
- Set a break point at line 227 in NavigationService
- Start minimal app in debug
- Type something in the text box and press submit
- Press Suspend and shutdown under lifecycle events
- Restart app, breakpoint should now be hit
