### PR TITLE
Example in converters to show x:Bind to an ItemSource control 

### DIFF
--- a/Samples/Converters/Converters.csproj
+++ b/Samples/Converters/Converters.csproj
@@ -96,6 +96,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Models\SimpleModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ViewModels\MainPageViewModel.cs" />
     <Compile Include="Views\MainPage.xaml.cs">

--- a/Samples/Converters/Models/SimpleModel.cs
+++ b/Samples/Converters/Models/SimpleModel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sample.Models
+{
+    public class SimpleModel
+    {
+        static Random r = new Random();
+        public SimpleModel()
+        {
+            IntProperty = r.Next(-int.MaxValue, +int.MaxValue);
+            DateProperty = DateTime.Today.AddDays(r.Next(-365, 365));
+        }
+
+        public int IntProperty { get; set; }
+        public DateTime DateProperty { get; set; }
+    }
+}

--- a/Samples/Converters/ViewModels/MainPageViewModel.cs
+++ b/Samples/Converters/ViewModels/MainPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Sample.Models;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -14,7 +15,6 @@ namespace Sample.ViewModels
         public MainPageViewModel()
         {
             Instance = this;
-
             NumberValues = new ObservableCollection<double>(
                 Enumerable.Range(0, 40).Select(i => i * 0.25463105308788066303)
             );
@@ -23,6 +23,12 @@ namespace Sample.ViewModels
             NumberValue = NumberValues[rand.Next(NumberValues.Count - 1)];
             BooleanValue = false;
             DateTimeValue = DateTime.UtcNow;
+
+            SimpleModels = new ObservableCollection<SimpleModel>();
+            for (int i = 0; i < 100; i++)
+            {
+                SimpleModels.Add(new SimpleModel());
+            }
         }
 
         public ObservableCollection<double> NumberValues { get; set; }
@@ -92,7 +98,7 @@ namespace Sample.ViewModels
         }
 
 
-        private Decimal _decimalValue=500.25M;
+        private Decimal _decimalValue = 500.25M;
         /// <summary>
         /// Sets and gets the MyProperty property.
         /// Changes to that property's value raise the PropertyChanged event. 
@@ -101,6 +107,32 @@ namespace Sample.ViewModels
         {
             get { return _decimalValue; }
             set { Set(ref _decimalValue, value); }
+        }
+
+
+
+        private ObservableCollection<SimpleModel> _simpleModels = null;
+        /// <summary>
+        /// Sets and gets the MyProperty property.
+        /// Changes to that property's value raise the PropertyChanged event. 
+        /// </summary>
+        public ObservableCollection<SimpleModel> SimpleModels
+        {
+            get { return _simpleModels; }
+            set { Set(ref _simpleModels, value); }
+        }
+
+
+
+        private SimpleModel _selectedSimpleModel = null;
+        /// <summary>
+        /// Sets and gets the SelectedSimpleModel property.
+        /// Changes to that property's value raise the PropertyChanged event. 
+        /// </summary>
+        public SimpleModel SelectedSimpleModel
+        {
+            get { return _selectedSimpleModel; }
+            set { Set(ref _selectedSimpleModel, value); }
         }
 
     }

--- a/Samples/Converters/Views/MainPage.xaml
+++ b/Samples/Converters/Views/MainPage.xaml
@@ -134,7 +134,7 @@
                 <TextBlock TextWrapping="Wrap" Text="Change Type Converter compiled binding" Style="{ThemeResource  TitleTextBlockStyle}"/>
                 <StackPanel Orientation="Horizontal">
                     <ComboBox ItemsSource="{x:Bind ViewModel.SimpleModels,Mode=OneWay}" 
-                              SelectedItem="{x:Bind ViewModel.SelectedSimpleModel,Mode=TwoWay,Converter={StaticResource ChangeTypeConverter}}" 
+                              SelectedValue="{x:Bind ViewModel.SelectedSimpleModel,Mode=TwoWay,Converter={StaticResource ChangeTypeConverter}}" 
                               Width="320" >
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
@@ -146,6 +146,7 @@
                         </ComboBox.ItemTemplate>
                     </ComboBox>
                     <Button x:Name="SetFirstComboItem" Content="Select first simple model from ViewModel" Margin="8,0" Click="SetFirstComboItem_Click"/>
+                    <Button x:Name="SetNullValueToCombo" Content="Clear Value from ViewModel" Margin="8,0" Click="SetNullValueToCombo_Click"/>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/Samples/Converters/Views/MainPage.xaml
+++ b/Samples/Converters/Views/MainPage.xaml
@@ -131,6 +131,22 @@
                     <TextBlock x:Name="ValueWhenConverterText" Text="Visibility is bound to CheckBox's IsChecked property" Visibility="{x:Bind CheckShowTextBox.IsChecked,Converter={StaticResource BooleanToVisibilityConverter},Mode=TwoWay}" VerticalAlignment="Center" Margin="4,0"/>
                 </StackPanel>
 
+                <TextBlock TextWrapping="Wrap" Text="Change Type Converter compiled binding" Style="{ThemeResource  TitleTextBlockStyle}"/>
+                <StackPanel Orientation="Horizontal">
+                    <ComboBox ItemsSource="{x:Bind ViewModel.SimpleModels,Mode=OneWay}" 
+                              SelectedItem="{x:Bind ViewModel.SelectedSimpleModel,Mode=TwoWay,Converter={StaticResource ChangeTypeConverter}}" 
+                              Width="320" >
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding IntProperty}"/>
+                                    <TextBlock Text="{Binding DateProperty, Converter={StaticResource StringFormatConverter}, ConverterParameter=' on {0:d}'}"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <Button x:Name="SetFirstComboItem" Content="Select first simple model from ViewModel" Margin="8,0" Click="SetFirstComboItem_Click"/>
+                </StackPanel>
             </StackPanel>
         </ScrollViewer>
         <!--  #endregion  -->

--- a/Samples/Converters/Views/MainPage.xaml.cs
+++ b/Samples/Converters/Views/MainPage.xaml.cs
@@ -38,5 +38,10 @@ namespace Sample.Views
         {
             ViewModel.SelectedSimpleModel = ViewModel.SimpleModels.FirstOrDefault();
         }
+
+        private void SetNullValueToCombo_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.SelectedSimpleModel = null;
+        }
     }
 }

--- a/Samples/Converters/Views/MainPage.xaml.cs
+++ b/Samples/Converters/Views/MainPage.xaml.cs
@@ -33,5 +33,10 @@ namespace Sample.Views
         {
             ValueWhenConverterText.Visibility = Visibility.Visible;
         }
+
+        private void SetFirstComboItem_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.SelectedSimpleModel = ViewModel.SimpleModels.FirstOrDefault();
+        }
     }
 }

--- a/Template10 (Library)/Converters/ChangeTypeConverter.cs
+++ b/Template10 (Library)/Converters/ChangeTypeConverter.cs
@@ -24,6 +24,9 @@ namespace Template10.Converters
             if (value == null && !targetType.IsByRef)
                 return Activator.CreateInstance(targetType);
 
+            if (targetType == typeof(object))
+                return (object)value;
+
             return System.Convert.ChangeType(value, targetType);
         }
 

--- a/Template10 (Library)/Converters/ChangeTypeConverter.cs
+++ b/Template10 (Library)/Converters/ChangeTypeConverter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Data;
+using System.Reflection;
 
 namespace Template10.Converters
 {
@@ -21,7 +22,7 @@ namespace Template10.Converters
                 targetType = Nullable.GetUnderlyingType(targetType);
             }
 
-            if (value == null && !targetType.IsByRef)
+            if (value == null && targetType.GetTypeInfo().IsValueType)
                 return Activator.CreateInstance(targetType);
 
             if (targetType == typeof(object))


### PR DESCRIPTION
with two way compiled binding on SelectedItem. Also changed ChangeTypeConverter not to throw must implement IConvertible when converting back to System.Object
