### PR TITLE
Added PageTitleVisibility property to PageHeader.This is required to …

### DIFF
--- a/Template10 (Library)/Controls/PageHeader.cs
+++ b/Template10 (Library)/Controls/PageHeader.cs
@@ -37,6 +37,17 @@ namespace Template10.Controls
         public static readonly DependencyProperty BackButtonVisibilityProperty =
             DependencyProperty.Register(nameof(BackButtonVisibility), typeof(Visibility), typeof(PageHeader), new PropertyMetadata(default(Visibility)));
 
+        
+
+        public Visibility PageTitleVisibility
+        {
+            get { return (Visibility)GetValue(PageTitleVisibilityProperty); }
+            set { SetValue(PageTitleVisibilityProperty, value); }
+        }
+
+        public static readonly DependencyProperty PageTitleVisibilityProperty =
+            DependencyProperty.Register(nameof(PageTitleVisibility), typeof(Visibility), typeof(PageHeader), new PropertyMetadata(Visibility.Visible));
+
         private Symbol BackButtonContent
         {
             get { return (Symbol)GetValue(BackButtonContentProperty); }

--- a/Template10 (Library)/Themes/Generic.xaml
+++ b/Template10 (Library)/Themes/Generic.xaml
@@ -727,6 +727,7 @@
                                                 Content="{TemplateBinding Content}"
                                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                                 ContentTransitions="{TemplateBinding ContentTransitions}"
+                                                Visibility="{TemplateBinding PageTitleVisibility}"
                                                 FontFamily="{TemplateBinding FontFamily}"
                                                 FontSize="{TemplateBinding FontSize}"
                                                 FontStretch="{TemplateBinding FontStretch}"


### PR DESCRIPTION
For PaneOpen and PaneClosed events to work as intended, a PageTitleVisibility property is required to work in conjunction with page Visual States.

**Event subscription example in a viewmodel ctor():**

`Views.Shell.HamburgerMenu.PaneOpen += (s, e) => { PageVisualState = "ShowTitleState"; };
             Views.Shell.HamburgerMenu.PaneClosed += (s, e) => { PageVisualState = "NarrowState"; };`

**Visual State setter fragment in XAML (ShowTitleState):**
`<Setter Target="pageHeader.PageTitleVisibility" Value="Visible"/>`

**Visual State setter fragment in XAML (NarrowState):**
`<Setter Target="pageHeader.PageTitleVisibility" Value="Collapsed"/>`

In View page, **DataTriggerBehavior** listens to a **PageVisualState** property in ViewModel to effect the **GoToStateAction** for visual state transition.
