### PR TITLE
Fixes for multiple nav services created after suspend/resume on mobile

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -299,7 +299,15 @@ namespace Template10.Common
         /// because the asunc operations are in a single, global deferral created when the suspension
         /// begins and completed automatically when the last viewmodel has been called (including this method).
         /// </summary>
-        public virtual async Task OnSuspendingAsync(object s, SuspendingEventArgs e) { await Task.Yield(); }
+        public virtual async Task OnSuspendingAsync(object s, SuspendingEventArgs e)
+        {
+            if (Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily.Equals("Windows.Mobile"))
+            {
+                WindowWrapper.ClearNavigationServices(Window.Current);
+            }
+            await Task.Yield();
+        }
+
         public virtual void OnResuming(object s, object e) { }
 
         #endregion

--- a/Template10 (Library)/Common/WindowWrapper.cs
+++ b/Template10 (Library)/Common/WindowWrapper.cs
@@ -2,10 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Template10.Services.NavigationService;
-using Windows.UI;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Media;
 
 namespace Template10.Common
 {
@@ -26,6 +23,15 @@ namespace Template10.Common
             ActiveWrappers.Add(this);
             Dispatcher = new DispatcherWrapper(window.Dispatcher);
             window.Closed += (s, e) => { ActiveWrappers.Remove(this); };
+        }
+
+        public static void ClearNavigationServices(Window window)
+        {
+            var wrapperToRemove = ActiveWrappers.FirstOrDefault(wrapper => object.ReferenceEquals(wrapper.Window, window));
+            if (wrapperToRemove != null)
+            {
+                wrapperToRemove.NavigationServices.Clear();
+            }
         }
 
         public void Close() { Window.Close(); }


### PR DESCRIPTION
Fixes #325 by clearing all cached navigation services when the app is suspending since these are **re**-created upon resume
