### PR TITLE
Invoke PropertyChanged handler from UI thread

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -61,7 +61,13 @@ namespace Template10.Common
         /// it is only a helper property to provide the NavigatioNService for
         /// the first Frame ultimately aggregated in the static WindowWrapper class.
         /// </summary>
-        public Services.NavigationService.INavigationService NavigationService => WindowWrapper.ActiveWrappers.First().NavigationServices.First();
+        public Services.NavigationService.INavigationService NavigationService => WindowWrapper.Default.NavigationServices.First();
+
+        /// <summary>
+        /// This is the DispatcherWrapper of the current WindowWrapper. This is used to get
+        /// the DispatcherWrapper of the "current" UI thread.
+        /// </summary>
+        public IDispatcherWrapper Dispatcher => WindowWrapper.Current().Dispatcher;
 
         /// <summary>
         /// The SplashFactory is a Func that returns an instantiated Splash view.

--- a/Template10 (Library)/Common/WindowWrapper.cs
+++ b/Template10 (Library)/Common/WindowWrapper.cs
@@ -9,9 +9,9 @@ namespace Template10.Common
     // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-WindowWrapper
     public class WindowWrapper
     {
-        public static WindowWrapper Default() => ActiveWrappers.FirstOrDefault();
+        public static WindowWrapper Default => ActiveWrappers.FirstOrDefault();
         public readonly static List<WindowWrapper> ActiveWrappers = new List<WindowWrapper>();
-        public static WindowWrapper Current() => ActiveWrappers.FirstOrDefault(x => x.Window == Window.Current) ?? Default();
+        public static WindowWrapper Current() => ActiveWrappers.FirstOrDefault(x => x.Window == Window.Current) ?? Default;
         public static WindowWrapper Current(Window window) => ActiveWrappers.FirstOrDefault(x => x.Window == window);
         public static WindowWrapper Current(INavigationService nav) => ActiveWrappers.FirstOrDefault(x => x.NavigationServices.Contains(nav));
 

--- a/Template10 (Library)/Mvvm/BindableBase.cs
+++ b/Template10 (Library)/Mvvm/BindableBase.cs
@@ -19,7 +19,7 @@ namespace Template10.Mvvm
             {
                 if (DesignMode.DesignModeEnabled)
                     return;
-                BootStrapper.Current.NavigationService.Dispatcher.Dispatch(() =>
+                BootStrapper.Current.Dispatcher.Dispatch(() =>
                 {
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
                 });
@@ -102,7 +102,7 @@ namespace Template10.Mvvm
             {
                 if (DesignMode.DesignModeEnabled)
                     return;
-                BootStrapper.Current.NavigationService.Dispatcher.Dispatch(() =>
+                BootStrapper.Current.Dispatcher.Dispatch(() =>
                 {
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
                 });

--- a/Template10 (Library)/Mvvm/BindableBase.cs
+++ b/Template10 (Library)/Mvvm/BindableBase.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Windows.UI.Xaml;
+using Windows.ApplicationModel;
 
 namespace Template10.Mvvm
 {
@@ -16,7 +17,12 @@ namespace Template10.Mvvm
         {
             try
             {
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                if (DesignMode.DesignModeEnabled)
+                    return;
+                BootStrapper.Current.NavigationService.Dispatcher.Dispatch(() =>
+                {
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                });
             }
             catch
             {
@@ -92,11 +98,14 @@ namespace Template10.Mvvm
 
         public void RaisePropertyChanged([CallerMemberName]string propertyName = null)
         {
-            if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
-                return;
             try
             {
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                if (DesignMode.DesignModeEnabled)
+                    return;
+                BootStrapper.Current.NavigationService.Dispatcher.Dispatch(() =>
+                {
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                });
             }
             catch
             {


### PR DESCRIPTION
This was initially present, has been removed some time back, wondering why. In the absence of this wrapping, sometimes we get the "The application called an interface that was marshalled for a different thread" exception. Initially in the Template 10 project (when it was only Template10, Blank and Minimal, before these Library and Services projects), it was present as `(App.BootStrapper).Dispatch(() =>{});`. In the current version I have referenced the path to the `DispatcherWrapper`. Maybe we can bring an `IDispatcherWrapper` reference into `BootStrapper` itself?
