### PR TITLE
Fix unhandled exceptions SettingsService

### DIFF
--- a/Template10 (Library)/Services/SettingsService/SettingsService.cs
+++ b/Template10 (Library)/Services/SettingsService/SettingsService.cs
@@ -51,12 +51,19 @@ namespace Template10.Services.SettingsService
         {
             try
             {
-                var type = typeof(T);
-                var converter = Converters.GetConverter(type);
-                var container = Values[key] as ApplicationDataCompositeValue;
-                var value = container["Value"] as string;
-                var converted = (T)converter.FromStore(value, type);
-                return converted;
+                if (Values.ContainsKey(key))
+                {
+                    var type = typeof(T);
+                    var converter = Converters.GetConverter(type);
+                    var container = Values[key] as ApplicationDataCompositeValue;
+                    if (container.ContainsKey("Value"))
+                    {
+                        var value = container["Value"] as string;
+                        var converted = (T)converter.FromStore(value, type);
+                        return converted;
+                    }
+                }
+                return fallback;
             }
             catch
             {


### PR DESCRIPTION
While debugging I noticed a few unhandled exceptions in the diagnostics tools windows in visual studio. The error was ignored because there is a fallback that will return in case of an exception. My understanding is that exceptions in general are not cheap and checking a dictionary key for presence is an easy workaround without any tradeoff.
