### PR TITLE
Posibility to show backbutton without items on backstack was added.

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -426,11 +426,13 @@ namespace Template10.Common
         }
 
         public const string DefaultTileID = "App";
+
+        public bool ForceShowShellBackButton { get; set; } = false;
         public void UpdateShellBackButton()
         {
             // show the shell back only if there is anywhere to go in the default frame
             SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
-                (ShowShellBackButton && NavigationService.Frame.CanGoBack)
+                (ShowShellBackButton && (NavigationService.Frame.CanGoBack || ForceShowShellBackButton))
                     ? AppViewBackButtonVisibility.Visible
                     : AppViewBackButtonVisibility.Collapsed;
         }


### PR DESCRIPTION
 I need to show back button without items on backstack.
Until now I'm adding dummy item to backstack to show shellbackbutton and delete dummy item to hide shellbackbutton.

With my change:

```
//show shell backbutton
BootStrapper.Current.ForceShowShellBackButton = true;
BootStrapper.Current.UpdateShellBackButton();

//hide shell backbutton
BootStrapper.Current.ForceShowShellBackButton = false;
BootStrapper.Current.UpdateShellBackButton();
```
