### PR TITLE
Add custom methods to serialize/deserialize for PageParam data

### DIFF
--- a/Samples/BottomAppBar/Views/Shell.xaml.cs
+++ b/Samples/BottomAppBar/Views/Shell.xaml.cs
@@ -22,7 +22,7 @@ namespace Sample.Views
         public static Shell Instance { get; set; }
         public static HamburgerMenu HamburgerMenu { get { return Instance.MyHamburgerMenu; } }
 
-        public Shell(NavigationService navigationService)
+        public Shell(INavigationService navigationService)
         {
             Instance = this;
             InitializeComponent();

--- a/Samples/Search/Views/Shell.xaml.cs
+++ b/Samples/Search/Views/Shell.xaml.cs
@@ -13,7 +13,7 @@ namespace Sample.Views
     {
         public static Shell Instance { get; set; }
         private static WindowWrapper Window { get; set; }
-        public Shell(NavigationService navigationService)
+        public Shell(INavigationService navigationService)
         {
             Instance = this;
             this.InitializeComponent();

--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -366,9 +366,17 @@ namespace Template10.Common
         /// A developer should call this when creating a new/secondary frame.
         /// The shell back button should only be setup one time.
         /// </summary>
-        public Services.NavigationService.NavigationService NavigationServiceFactory(BackButton backButton, ExistingContent existingContent)
+        public Services.NavigationService.INavigationService NavigationServiceFactory(BackButton backButton, ExistingContent existingContent)
         {
             return NavigationServiceFactory(backButton, existingContent, new Frame());
+        }
+
+        /// <summary>
+        /// Creates the NavigationService instance for given Frame.
+        /// </summary>
+        protected virtual Services.NavigationService.INavigationService CreateNavigationService(Frame frame)
+        {
+            return new Services.NavigationService.NavigationService(frame);
         }
 
         /// <summary>
@@ -378,12 +386,12 @@ namespace Template10.Common
         /// A developer should call this when creating a new/secondary frame.
         /// The shell back button should only be setup one time.
         /// </summary>
-        public Services.NavigationService.NavigationService NavigationServiceFactory(BackButton backButton, ExistingContent existingContent, Frame frame)
+        public Services.NavigationService.INavigationService NavigationServiceFactory(BackButton backButton, ExistingContent existingContent, Frame frame)
         {
             frame.Language = Windows.Globalization.ApplicationLanguages.Languages[0];
             frame.Content = (existingContent == ExistingContent.Include) ? Window.Current.Content : null;
 
-            var navigationService = new Services.NavigationService.NavigationService(frame);
+            var navigationService = CreateNavigationService(frame);
             navigationService.FrameFacade.BackButtonHandling = backButton;
             WindowWrapper.Current().NavigationServices.Add(navigationService);
 

--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -108,7 +108,7 @@ namespace Template10.Services.NavigationService
             var key = GetPageStateKey(type);
             if (FrameStateContainer().Containers.ContainsKey(key))
                 FrameStateContainer().DeleteContainer(key);
-			pageStateContainers.Remove(type);
+            pageStateContainers.Remove(type);
         }
 
         #endregion

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -236,7 +236,10 @@ namespace Template10.Services.NavigationService
                 FrameFacade.CurrentPageParam = DeserializePageParam(state["CurrentPageParam"]?.ToString());
                 FrameFacade.SetNavigationState(state["NavigateState"]?.ToString());
                 NavigateTo(NavigationMode.Refresh, FrameFacade.CurrentPageParam);
-                while (Frame.Content == null) { /* wait */ }
+                while (Frame.Content == null)
+                {
+                    Task.Yield().GetAwaiter().GetResult();
+                }
                 AfterRestoreSavedNavigation?.Invoke(this, FrameFacade.CurrentPageType);
                 return true;
             }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -25,7 +25,7 @@ namespace Template10.Services.NavigationService
 
         public DispatcherWrapper Dispatcher => WindowWrapper.Current(this).Dispatcher;
 
-        protected internal NavigationService(Frame frame)
+        public NavigationService(Frame frame)
         {
             FrameFacade = new FrameFacade(frame);
             FrameFacade.Navigating += async (s, e) =>

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -97,6 +97,8 @@ namespace Template10.Services.NavigationService
 
         void NavigateTo(NavigationMode mode, object parameter)
         {
+            parameter = DeserializePageParam(parameter);
+
             LastNavigationParameter = parameter;
             LastNavigationType = FrameFacade.Content.GetType().FullName;
 
@@ -166,6 +168,7 @@ namespace Template10.Services.NavigationService
                     return false;
             }
 
+            parameter = SerializePageParam(parameter);
             return FrameFacade.Navigate(page, parameter, infoOverride);
         }
 
@@ -300,14 +303,14 @@ namespace Template10.Services.NavigationService
         public Type CurrentPageType => FrameFacade.CurrentPageType;
         public object CurrentPageParam => FrameFacade.CurrentPageParam;
 
-        protected virtual string SerializePageParam(object pageParam)
+        protected virtual object SerializePageParam(object pageParam)
         {
-            return pageParam?.ToString();
+            return pageParam;
         }
 
-        protected virtual object DeserializePageParam(string pageParamString)
+        protected virtual object DeserializePageParam(object pageParam)
         {
-            return pageParamString;
+            return pageParam;
         }
     }
 }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -25,7 +25,7 @@ namespace Template10.Services.NavigationService
 
         public DispatcherWrapper Dispatcher => WindowWrapper.Current(this).Dispatcher;
 
-        internal NavigationService(Frame frame)
+        protected internal NavigationService(Frame frame)
         {
             FrameFacade = new FrameFacade(frame);
             FrameFacade.Navigating += async (s, e) =>

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -25,7 +25,7 @@ namespace Template10.Services.NavigationService
 
         public DispatcherWrapper Dispatcher => WindowWrapper.Current(this).Dispatcher;
 
-        public NavigationService(Frame frame)
+        protected internal NavigationService(Frame frame)
         {
             FrameFacade = new FrameFacade(frame);
             FrameFacade.Navigating += async (s, e) =>

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -220,7 +220,6 @@ namespace Template10.Services.NavigationService
             try { state["CurrentPageParam"] = CurrentPageParam; }
             catch
             {
-                throw new Exception("Failed to serialize page parameter, override/implement ToString()");
             }
             state["NavigateState"] = FrameFacade?.GetNavigationState();
         }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -217,10 +217,7 @@ namespace Template10.Services.NavigationService
             }
 
             state["CurrentPageType"] = CurrentPageType.AssemblyQualifiedName;
-            try { state["CurrentPageParam"] = CurrentPageParam; }
-            catch
-            {
-            }
+            state["CurrentPageParam"] = SerializePageParam(CurrentPageParam);
             state["NavigateState"] = FrameFacade?.GetNavigationState();
         }
 
@@ -236,8 +233,8 @@ namespace Template10.Services.NavigationService
                 }
 
                 FrameFacade.CurrentPageType = Type.GetType(state["CurrentPageType"].ToString());
-                FrameFacade.CurrentPageParam = state["CurrentPageParam"];
-                FrameFacade.SetNavigationState(state["NavigateState"].ToString());
+                FrameFacade.CurrentPageParam = DeserializePageParam(state["CurrentPageParam"]?.ToString());
+                FrameFacade.SetNavigationState(state["NavigateState"]?.ToString());
                 NavigateTo(NavigationMode.Refresh, FrameFacade.CurrentPageParam);
                 while (Frame.Content == null) { /* wait */ }
                 AfterRestoreSavedNavigation?.Invoke(this, FrameFacade.CurrentPageType);
@@ -299,6 +296,16 @@ namespace Template10.Services.NavigationService
 
         public Type CurrentPageType => FrameFacade.CurrentPageType;
         public object CurrentPageParam => FrameFacade.CurrentPageParam;
+
+        protected virtual string SerializePageParam(object pageParam)
+        {
+            return pageParam?.ToString();
+        }
+
+        protected virtual object DeserializePageParam(string pageParamString)
+        {
+            return pageParamString;
+        }
     }
 }
 

--- a/Templates (Project)/Minimal/Views/Shell.xaml.cs
+++ b/Templates (Project)/Minimal/Views/Shell.xaml.cs
@@ -26,14 +26,14 @@ namespace Sample.Views
             SettingsButton.IsEnabled = false;
         }
 
-        public Shell(NavigationService navigationService)
+        public Shell(INavigationService navigationService)
         {
             Instance = this;
             InitializeComponent();
             SetNavigationService(navigationService);
         }
 
-        public void SetNavigationService(NavigationService navigationService)
+        public void SetNavigationService(INavigationService navigationService)
         {
             MyHamburgerMenu.NavigationService = navigationService;
         }


### PR DESCRIPTION
**\* This is an updated (rebased) request for #388.

This pull requests adds two additional methods to NavigationService to serialize and deserialize CurrentPageParam object into strings. These methods only call ToString() in default implementation, if custom behavior is neccessary, you can create a descendent class of NavigationService and extend it in your project.

To make it possible to use a custom NavigationService, I've also added a simply factory method to Bootstrapper.cs which can also be overridden in custom App.xaml.cs class to create a custom NavigationService.

Third, I've added a Task.Yield().GetAwaiter().GetResult() call while wating for Frame.Content to become available on resume. There has been a while(...) {} statement, which eats up CPU while waiting, a yield is better here.

For code cleanup, I also changed several NavigationService to INavigationService in Bootstrapper and Shell.xaml.cs.
