### PR TITLE
Sharing navigation button

### DIFF
--- a/Template10 (Library)/Controls/HamburgerButtonInfo.cs
+++ b/Template10 (Library)/Controls/HamburgerButtonInfo.cs
@@ -92,7 +92,14 @@ namespace Template10.Controls
             set { Set(ref _MaxWidth, value); }
         }
 
-        public override string ToString() => string.Format("{0}({1})", PageType?.ToString() ?? "null", PageParameter?.ToString() ?? "null");
+		string _navigationGroup;
+		public string NavigationGroup
+		{
+			get { return _navigationGroup; }
+			set { Set(ref _navigationGroup, value); }
+		}
+
+		public override string ToString() => string.Format("{0}({1})", PageType?.ToString() ?? "null", PageParameter?.ToString() ?? "null");
 
         public event RoutedEventHandler Selected;
         internal void RaiseSelected()

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -80,16 +80,19 @@ namespace Template10.Controls
 
         void HighlightCorrectButton(Type pageType = null, object pageParam = null)
         {
-            if (!AutoHighlightCorrectButton)
-                return;
-            pageType = pageType ?? NavigationService.CurrentPageType;
-            pageParam = pageParam ?? NavigationService.CurrentPageParam;
-            var values = _navButtons.Select(x => x.Value);
-            var button = values.FirstOrDefault(x => x.PageType == pageType 
-                && (x.PageParameter == null 
-                || x.PageParameter.Equals(pageParam)));
-            Selected = button;
-        }
+			if (!AutoHighlightCorrectButton)
+				return;
+			pageType = pageType ?? NavigationService.CurrentPageType;
+			var navGroup = pageType.GetTypeInfo().GetCustomAttribute<NavigationGroupAttribute>();
+			pageParam = pageParam ?? NavigationService.CurrentPageParam;
+			var values = _navButtons.Select(x => x.Value);
+			var button = values.FirstOrDefault(x => x.PageType == pageType
+				&& (x.PageParameter == null
+				|| x.PageParameter.Equals(pageParam)));
+			if (button == null && navGroup != null)
+				button = values.FirstOrDefault(x => navGroup.GroupName.Equals(x.NavigationGroup));
+			Selected = button;
+		}
 
         #region commands
 

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -393,8 +393,6 @@ namespace Template10.Controls
             set
             {
                 HamburgerButtonInfo oldValue = Selected;
-                if (AutoHighlightCorrectButton && (value?.Equals(oldValue) ?? false))
-                    value.IsChecked = (value.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle);
                 SetValue(SelectedProperty, value);
                 this.SelectedChanged?.Invoke(this, new ChangedEventArgs<HamburgerButtonInfo>(oldValue, value));
             }
@@ -427,7 +425,8 @@ namespace Template10.Controls
             }
             else
             {
-                value.IsChecked = (value.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle);
+				if (AutoHighlightCorrectButton)
+					value.IsChecked = (value.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle);
                 if (previous != value)
                 {
                     value.RaiseSelected();

--- a/Template10 (Library)/Services/NavigationService/NavigationGroupAttribute.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationGroupAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Template10.Services.NavigationService {
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+	public class NavigationGroupAttribute : Attribute
+	{
+		public string GroupName { get; private set; }
+
+		public NavigationGroupAttribute(string groupName)
+		{
+			if (String.IsNullOrEmpty(groupName))
+				throw new ArgumentNullException(nameof(groupName));
+
+			GroupName = groupName;
+		}
+	}
+}

--- a/Template10 (Library)/Template10 (Library).csproj
+++ b/Template10 (Library)/Template10 (Library).csproj
@@ -166,6 +166,7 @@
     <Compile Include="Services\NavigationService\AlternativeNavigationEventArgs.cs" />
     <Compile Include="Services\NavigationService\INavigationService.cs" />
     <Compile Include="Services\NavigationService\JournalEntry.cs" />
+    <Compile Include="Services\NavigationService\NavigationGroupAttribute.cs" />
     <Compile Include="Services\NavigationService\NavigationServiceList.cs" />
     <Compile Include="Services\SettingsService\ISettingsHelper.cs" />
     <Compile Include="Services\SettingsService\SettingsService.cs" />


### PR DESCRIPTION
The same navigation button can be selected when navigating to more than one page, based on attached to the page attribute.
Resolves #395 
