### PR TITLE
Parameter serialization refactorings to fix bugs/inconsistencies

### DIFF
--- a/Samples/ParameterSerializationService/JsonParameterSerializationService.cs
+++ b/Samples/ParameterSerializationService/JsonParameterSerializationService.cs
@@ -1,0 +1,107 @@
+using System;
+
+namespace Neusta.Commons.Template10.Utils
+{
+	using System.Text;
+	using global::Template10.Services.NavigationService;
+	using Newtonsoft.Json;
+
+	public class JsonParameterSerializationService : ParameterSerializationService
+	{
+		private volatile Tuple<object, string> lastObject = new Tuple<object, string>(null, null);
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="JsonParameterSerializationService"/> class.
+		/// </summary>
+		private JsonParameterSerializationService()
+		{
+		}
+
+		/// <summary>
+		/// Initializes this service.
+		/// </summary>
+		public static void Initialize()
+		{
+			ParameterSerializationService.Instance = new JsonParameterSerializationService();
+		}
+
+		#region Overrides of ParameterSerializationService
+
+		/// <summary>
+		/// Serializes the page parameter.
+		/// </summary>
+		public override object SerializeParameter(object parameter)
+		{
+			if (parameter.IsNull())
+			{
+				return null;
+			}
+			var parameterString = parameter as string;
+			if (parameterString.IsNotNull())
+			{
+				return parameterString;
+			}
+
+			// Check for last object
+			var last = this.lastObject;
+			if (last.Item1 == parameter)
+			{
+				return last.Item2;
+			}
+
+			// Serialize object to json
+			var sb = new StringBuilder();
+			sb.Append((char)9);
+			sb.Append(parameter.GetType().AssemblyQualifiedName);
+			sb.Append((char)9);
+			string data = JsonConvert.SerializeObject(parameter);
+			sb.Append(data);
+			parameterString = sb.ToString();
+
+			// Save last object
+			this.lastObject = new Tuple<object, string>(parameter, parameterString);
+
+			return parameterString;
+		}
+
+		/// <summary>
+		/// Deserializes the page parameter.
+		/// </summary>
+		public override object DeserializeParameter(object parameter)
+		{
+			var parameterString = parameter as string;
+			if (string.IsNullOrEmpty(parameterString) || (parameterString[0] != (char)9))
+			{
+				return parameter;
+			}
+
+			// Check for last object
+			var last = this.lastObject;
+			if (last.Item2 == parameterString)
+			{
+				return last.Item1;
+			}
+
+			// Try to deserialize object from json
+			try
+			{
+				int idx = parameterString.IndexOf((char)9, 2);
+				string typeName = parameterString.Substring(1, idx - 1);
+				Type type = Type.GetType(typeName);
+				string data = parameterString.Substring(idx + 1);
+				parameter = JsonConvert.DeserializeObject(data, type);
+			}
+			catch
+			{
+				parameter = null;
+			}
+
+			// Save last object
+			this.lastObject = new Tuple<object, string>(parameter, parameterString);
+
+			return parameter;
+		}
+
+		#endregion
+	}
+}

--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -201,7 +201,7 @@ namespace Template10.Services.NavigationService
         void FacadeNavigatedEventHandler(object sender, Windows.UI.Xaml.Navigation.NavigationEventArgs e)
         {
             CurrentPageType = e.SourcePageType;
-            CurrentPageParam = e.Parameter;
+            CurrentPageParam = ParameterSerializationService.Instance.DeserializeParameter(e.Parameter);
             var args = new NavigatedEventArgs(e, Content as Page);
             if (NavigationModeHint != NavigationMode.New)
                 args.NavigationMode = NavigationModeHint;
@@ -220,7 +220,8 @@ namespace Template10.Services.NavigationService
         }
         private void FacadeNavigatingCancelEventHandler(object sender, NavigatingCancelEventArgs e)
         {
-            var args = new NavigatingEventArgs(e, Content as Page);
+            var parameter = ParameterSerializationService.Instance.DeserializeParameter(e.Parameter);
+            var args = new NavigatingEventArgs(e, Content as Page, parameter);
             if (NavigationModeHint != NavigationMode.New)
                 args.NavigationMode = NavigationModeHint;
             NavigationModeHint = NavigationMode.New;

--- a/Template10 (Library)/Services/NavigationService/NavigatingEventArgs.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigatingEventArgs.cs
@@ -7,12 +7,12 @@ namespace Template10.Services.NavigationService
     public class NavigatingEventArgs: NavigatedEventArgs
     {
         public NavigatingEventArgs() { }
-        public NavigatingEventArgs(NavigatingCancelEventArgs e, Page page)
+        public NavigatingEventArgs(NavigatingCancelEventArgs e, Page page, object parameter)
         {
-            this.Page = page;
             this.NavigationMode = e.NavigationMode;
             this.PageType = e.SourcePageType;
-            this.Parameter = e.Parameter?.ToString();
+            this.Page = page;
+            this.Parameter = parameter;
         }
         public bool Cancel { get; set; } = false;
         public bool Suspending { get; set; } = false;

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -13,9 +13,9 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Template10.Services.NavigationService
 {
-	using Windows.UI.Xaml.Data;
+    using Windows.UI.Xaml.Data;
 
-	// DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
     public partial class NavigationService : INavigationService
     {
         private const string EmptyNavigation = "1,0";

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -13,7 +13,9 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Template10.Services.NavigationService
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
+	using Windows.UI.Xaml.Data;
+
+	// DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
     public partial class NavigationService : INavigationService
     {
         private const string EmptyNavigation = "1,0";
@@ -42,7 +44,7 @@ namespace Template10.Services.NavigationService
             };
             FrameFacade.Navigated += (s, e) =>
             {
-                NavigateTo(e.NavigationMode, e.Parameter);
+                NavigateTo(e.NavigationMode, ParameterSerializationService.Instance.DeserializeParameter(e.Parameter));
             };
         }
 
@@ -97,8 +99,6 @@ namespace Template10.Services.NavigationService
 
         void NavigateTo(NavigationMode mode, object parameter)
         {
-            parameter = DeserializePageParam(parameter);
-
             LastNavigationParameter = parameter;
             LastNavigationType = FrameFacade.Content.GetType().FullName;
 
@@ -168,7 +168,7 @@ namespace Template10.Services.NavigationService
                     return false;
             }
 
-            parameter = SerializePageParam(parameter);
+            parameter = ParameterSerializationService.Instance.SerializeParameter(parameter);
             return FrameFacade.Navigate(page, parameter, infoOverride);
         }
 
@@ -220,7 +220,7 @@ namespace Template10.Services.NavigationService
             }
 
             state["CurrentPageType"] = CurrentPageType.AssemblyQualifiedName;
-            state["CurrentPageParam"] = SerializePageParam(CurrentPageParam);
+            state["CurrentPageParam"] = ParameterSerializationService.Instance.SerializeParameter(CurrentPageParam);
             state["NavigateState"] = FrameFacade?.GetNavigationState();
         }
 
@@ -236,7 +236,7 @@ namespace Template10.Services.NavigationService
                 }
 
                 FrameFacade.CurrentPageType = Type.GetType(state["CurrentPageType"].ToString());
-                FrameFacade.CurrentPageParam = DeserializePageParam(state["CurrentPageParam"]?.ToString());
+                FrameFacade.CurrentPageParam = ParameterSerializationService.Instance.DeserializeParameter(state["CurrentPageParam"]?.ToString());
                 FrameFacade.SetNavigationState(state["NavigateState"]?.ToString());
                 NavigateTo(NavigationMode.Refresh, FrameFacade.CurrentPageParam);
                 while (Frame.Content == null)
@@ -302,16 +302,6 @@ namespace Template10.Services.NavigationService
 
         public Type CurrentPageType => FrameFacade.CurrentPageType;
         public object CurrentPageParam => FrameFacade.CurrentPageParam;
-
-        protected virtual object SerializePageParam(object pageParam)
-        {
-            return pageParam;
-        }
-
-        protected virtual object DeserializePageParam(object pageParam)
-        {
-            return pageParam;
-        }
     }
 }
 

--- a/Template10 (Library)/Services/NavigationService/ParameterSerializationService.cs
+++ b/Template10 (Library)/Services/NavigationService/ParameterSerializationService.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Template10.Services.NavigationService
+{
+    public class ParameterSerializationService
+    {
+        private static volatile ParameterSerializationService instance = new ParameterSerializationService();
+
+        /// <summary>
+        /// Gets or sets the instance that should be used to serialize/deserialize.
+        /// </summary>
+        public static ParameterSerializationService Instance
+        {
+            get { return instance; }
+            set { instance = value; }
+        }
+
+        /// <summary>
+        /// Serializes the parameter.
+        /// </summary>
+        public virtual object SerializeParameter(object parameter)
+        {
+            return parameter;
+        }
+
+        /// <summary>
+        /// Deserializes the parameter.
+        /// </summary>
+        public virtual object DeserializeParameter(object parameter)
+        {
+            return parameter;
+        }
+    }
+}

--- a/Template10 (Library)/Template10 (Library).csproj
+++ b/Template10 (Library)/Template10 (Library).csproj
@@ -167,6 +167,7 @@
     <Compile Include="Services\NavigationService\INavigationService.cs" />
     <Compile Include="Services\NavigationService\JournalEntry.cs" />
     <Compile Include="Services\NavigationService\NavigationServiceList.cs" />
+    <Compile Include="Services\NavigationService\ParameterSerializationService.cs" />
     <Compile Include="Services\SettingsService\ISettingsHelper.cs" />
     <Compile Include="Services\SettingsService\SettingsService.cs" />
     <Compile Include="Services\SettingsService\SettingsStrategy.cs" />


### PR DESCRIPTION
Unfortunately, there have been some inconsistencies in my last pull request to serialize/deserialize navigation parameters. This pull request fixes this.

It was not enough to add the methods to the NavigationService because I also need to call them from FrameFacade. The NavigationService is not available there. So I added a new service class that is a simple singleton, implements two methods that return the parameter unchanged. This service can be enhanced in customer projects to handle complex serialization/deserialization.

Because the current default implementation returns the parameter unchanged, you are not affected by these bugs when not using a custom implementation.

I've also added a simple JsonParameterSerializationService to the samples (without sample project). To use this service, simply call `JsonParameterSerializationService.Initialize();`. The sample also contains a very simple cache that prevents deserializing the same class again.
