### PR TITLE
Add missing UpdateFullScreen() call then NavigationService is set

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -524,7 +524,7 @@ namespace Template10.Controls
                     };
                 }
 
-                UpdateFullScreen(true);
+                UpdateFullScreen();
 
                 NavigationService.AfterRestoreSavedNavigation += (s, e) => HighlightCorrectButton();
                 NavigationService.FrameFacade.Navigated += (s, e) => HighlightCorrectButton(e.PageType, e.Parameter);

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -554,9 +554,7 @@ namespace Template10.Controls
             var frame = NavigationService?.Frame;
             if (manual ?? IsFullScreen)
             {
-                if (NavigationService == null || RootGrid.Children.Contains(frame))
-                    return;
-                if (!RootGrid.Children.Contains(frame))
+                if (!RootGrid.Children.Contains(frame) && frame != null)
                 {
                     ShellSplitView.Content = null;
                     RootGrid.Children.Add(frame);
@@ -570,11 +568,11 @@ namespace Template10.Controls
             }
             else
             {
-                if (RootGrid.Children.Contains(frame))
+                if (RootGrid.Children.Contains(frame) && frame != null)
                 {
                     RootGrid.Children.Remove(frame);
-                    ShellSplitView.Content = frame;
                 }
+                ShellSplitView.Content = frame;
                 if (!RootGrid.Children.Contains(ShellSplitView))
                     RootGrid.Children.Add(ShellSplitView);
                 if (!RootGrid.Children.Contains(HamburgerButton))

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -524,6 +524,8 @@ namespace Template10.Controls
                     };
                 }
 
+                UpdateFullScreen(true);
+
                 NavigationService.AfterRestoreSavedNavigation += (s, e) => HighlightCorrectButton();
                 NavigationService.FrameFacade.Navigated += (s, e) => HighlightCorrectButton(e.PageType, e.Parameter);
             }


### PR DESCRIPTION
Add missing UpdateFullScreen() call in NavigationService setter. This is very important if the first view not show a HamburgerMenu and the app does not have a Splash screen.
