### PR TITLE
Add new methods to Bootstrapper

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -44,7 +44,13 @@ namespace Template10.Common
         protected BootStrapper()
         {
             Current = this;
-            Resuming += (s, e) => { OnResuming(s, e); };
+            Resuming += async (s, e) =>
+            {
+#pragma warning disable 618
+                OnResuming(s, e);
+#pragma warning restore 618
+                await OnResumingAsync(s, e);
+            };
             Suspending += async (s, e) =>
             {
                 // one, global deferral
@@ -319,7 +325,35 @@ namespace Template10.Common
             await Task.CompletedTask;
         }
 
+        [Obsolete("Use OnResumingAsync")]
         public virtual void OnResuming(object s, object e) { }
+
+        /// <summary>
+        /// OnResumingAsync will be called when the application is resuming.
+        /// </summary>
+        public virtual async Task OnResumingAsync(object s, object e)
+        {
+            await Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// OnSaveNavigationAsync will be called immediately before the navigation services
+        /// saves the current navigation state. This normally happens before the application
+        /// is suspend.
+        /// </summary>
+        public virtual async Task OnSaveNavigationAsync(INavigationService navigationService, Type currentPageType)
+        {
+            await Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// OnRestoredNavigationAsync will be called after navigation state was restored by
+        /// the navigation service.
+        /// </summary>
+        public virtual async Task OnRestoredNavigationAsync(INavigationService navigationService, Type currentPageType)
+        {
+            await Task.CompletedTask;
+        }
 
         #endregion
 
@@ -404,6 +438,8 @@ namespace Template10.Common
             }
 
             var navigationService = CreateNavigationService(frame);
+            navigationService.BeforeSaveNavigation += async (s, t) => await OnSaveNavigationAsync((INavigationService)s, t);
+            navigationService.AfterRestoreSavedNavigation += async (s, t) => await OnRestoredNavigationAsync((INavigationService)s, t);
             navigationService.FrameFacade.BackButtonHandling = backButton;
             WindowWrapper.Current().NavigationServices.Add(navigationService);
 

--- a/Template10 (Library)/Services/NavigationService/INavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/INavigationService.cs
@@ -17,6 +17,7 @@ namespace Template10.Services.NavigationService
         Frame Frame { get; }
         FrameFacade FrameFacade { get; }
 
+        event TypedEventHandler<Type> BeforeSaveNavigation;
         event TypedEventHandler<Type> AfterRestoreSavedNavigation;
 
 		void ClearCache(bool removeCachedPagesInBackStack = false);

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -208,8 +208,11 @@ namespace Template10.Services.NavigationService
             return FrameFacade.Navigate(page, parameter, infoOverride);
         }
 
+        public event TypedEventHandler<Type> BeforeSaveNavigation;
         public void SaveNavigation()
         {
+            BeforeSaveNavigation?.Invoke(this, CurrentPageType);
+
             if (CurrentPageType == null)
                 return;
 


### PR DESCRIPTION
This pull request adds three new methods to Bootstrapper.

**OnResumingAsync:**
Same as OnResuming, but async to allow users to call and await other async methods. The old method OnResuming has been marked as Obsolete but is still called.

**OnRestoredNavigationAsync:**
This method is invoked when the navigation service restored the navigation. This method is normally called when app is restored from resume and resume+terminated state.

**OnSaveNavigationAsync:**
This method is invoked immediately before the navigation service saves the navigation state. It allows "last minute" changes on the navigation state.
