### PR TITLE
Change Page.BottomAppBar to use CommandBar instead

### DIFF
--- a/Samples/BottomAppBar/Views/MainPage.xaml
+++ b/Samples/BottomAppBar/Views/MainPage.xaml
@@ -10,23 +10,26 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:vm="using:Sample.ViewModels" mc:Ignorable="d">
 
-    <Page.BottomAppBar>
-        <AppBar>
-            <StackPanel Orientation="Horizontal">
-                <AppBarButton Icon="Save" Label="Save" Click="SampleClick" />
-                <AppBarButton Icon="OpenFile" Label="Open" Click="SampleClick" />
-            </StackPanel>
-        </AppBar>
-    </Page.BottomAppBar>
-
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+      <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" /> <!-- Header Row -->
+            <RowDefinition Height="*" /> <!-- Content Row -->
+            <RowDefinition Height="Auto" /> <!-- CommandBar Row -->
+      </Grid.RowDefinitions>
 
-        <controls:PageHeader Content="Bottom App Bar Sample">
+        <controls:PageHeader Content="Bottom App Bar Sample" Grid.Row="0">
             <Interactivity:Interaction.Behaviors>
                 <Behaviors:EllipsisBehavior Visibility="Collapsed" />
             </Interactivity:Interaction.Behaviors>
         </controls:PageHeader>
-
+        
+        
+    <Grid x:Name="BottomBar" Grid.Row="2">
+        <CommandBar ClosedDisplayMode="Compact">
+                <AppBarButton Icon="Save" Label="Save" Click="SampleClick" />
+                <AppBarButton Icon="OpenFile" Label="Open" Click="SampleClick" />
+        </CommandBar>
+    </Grid>
     </Grid>
 </Page>
 

--- a/Samples/BottomAppBar/Views/MainPage.xaml.cs
+++ b/Samples/BottomAppBar/Views/MainPage.xaml.cs
@@ -9,18 +9,8 @@ namespace Sample.Views
         public MainPage()
         {
             InitializeComponent();
-
-            var ham = Shell.HamburgerMenu;
-            ham.PaneOpened += (s, e) => UpdateMargin(ham);
-            ham.PaneClosed += (s, e) => UpdateMargin(ham);
-            UpdateMargin(ham);
         }
 
-        private void UpdateMargin(HamburgerMenu ham)
-        {
-            var value = (ham.IsOpen) ? ham.PaneWidth : 48d;
-            BottomAppBar.Margin = new Thickness(value, 0, 0, 0);
-        }
 
 private void SampleClick(object sender, RoutedEventArgs e)
 {

--- a/Samples/BottomAppBar/Views/MainPage.xaml.cs
+++ b/Samples/BottomAppBar/Views/MainPage.xaml.cs
@@ -15,11 +15,9 @@ namespace Sample.Views
 private void SampleClick(object sender, RoutedEventArgs e)
 {
     Shell.SetBusy(true, "Please wait...");
-    BottomAppBar.IsEnabled = false;
     Template10.Common.WindowWrapper.Current().Dispatcher.Dispatch(() =>
     {
         Shell.SetBusy(false);
-        BottomAppBar.IsEnabled = true;
     }, 3000);
 }
     }

--- a/Samples/BottomAppBar/readme.md
+++ b/Samples/BottomAppBar/readme.md
@@ -1,3 +1,8 @@
+Instead of changing the margin of BottomAppBar, I removed Page.BottomAppBar, and added a <Grid><CommandBar/></Grid> inside the root Grid, since this will behave like any other control on the page, the SplitView.Pane will not be occluded. 
+
+Old Method below
+
+
 ﻿It turns out that the BottomAppBar property of Page, when set, occludes the SpltView.Pane. This is because it is drawn over the content, even though the page is nested inside the SplitView. The SplitView is a good choice for developers who want a bottom app bar and want their bottom app bar to move when the soft keyboard is displayed. I personally think this is a 1% case, but it is real. 
 
 What to do?

--- a/Samples/BottomAppBar/readme.md
+++ b/Samples/BottomAppBar/readme.md
@@ -1,9 +1,36 @@
-Instead of changing the margin of BottomAppBar, I removed Page.BottomAppBar, and added a <Grid><CommandBar/></Grid> inside the root Grid, since this will behave like any other control on the page, the SplitView.Pane will not be occluded. 
+Instead of changing the margin of BottomAppBar, I removed Page.BottomAppBar, and added a CommandBar inside the root Grid, since this will behave like any other control on the page, the SplitView.Pane will not be occluded. 
 
-Old Method below
+````xaml
+ <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+      <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" /> <!-- Header Row -->
+            <RowDefinition Height="*" /> <!-- Content Row -->
+            <RowDefinition Height="Auto" /> <!-- CommandBar Row -->
+      </Grid.RowDefinitions>
+
+        <controls:PageHeader Content="Bottom App Bar Sample" Grid.Row="0">
+            <Interactivity:Interaction.Behaviors>
+                <Behaviors:EllipsisBehavior Visibility="Collapsed" />
+            </Interactivity:Interaction.Behaviors>
+        </controls:PageHeader>
+        
+        
+    <Grid x:Name="BottomBar" Grid.Row="2">
+        <CommandBar ClosedDisplayMode="Compact">
+                <AppBarButton Icon="Save" Label="Save" Click="SampleClick" />
+                <AppBarButton Icon="OpenFile" Label="Open" Click="SampleClick" />
+        </CommandBar>
+    </Grid>
+    </Grid>
+````
 
 
-﻿It turns out that the BottomAppBar property of Page, when set, occludes the SpltView.Pane. This is because it is drawn over the content, even though the page is nested inside the SplitView. The SplitView is a good choice for developers who want a bottom app bar and want their bottom app bar to move when the soft keyboard is displayed. I personally think this is a 1% case, but it is real. 
+
+
+Old Method below:
+
+
+It turns out that the BottomAppBar property of Page, when set, occludes the SpltView.Pane. This is because it is drawn over the content, even though the page is nested inside the SplitView. The SplitView is a good choice for developers who want a bottom app bar and want their bottom app bar to move when the soft keyboard is displayed. I personally think this is a 1% case, but it is real. 
 
 What to do?
 


### PR DESCRIPTION
Change Page.BottomAppBar to use a Grid with a CommandBar instead, this fixes the issue where the BottomAppBar occludes the SplitView.Pane. 
Since the CommandBar resides in the root Grid of the View, it will behave like any other control, meaning it will not occlude the SplitView.Pane. 
