### PR TITLE
Block PropertyChanged events on outdated ViewModels

### DIFF
--- a/Template10 (Library)/Mvvm/ViewModelBase.cs
+++ b/Template10 (Library)/Mvvm/ViewModelBase.cs
@@ -13,8 +13,8 @@ namespace Template10.Mvvm
     // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-MVVM
     public abstract class ViewModelBase : BindableBase, INavigable
     {
-        private volatile bool isNavigatedTo;
-        private volatile bool isNavigatedFrom;
+        private bool isNavigatedTo;
+        private bool isNavigatedFrom;
 
         [JsonIgnore]
         public bool IsNavigatedTo => isNavigatedTo;

--- a/Template10 (Library)/Mvvm/ViewModelBase.cs
+++ b/Template10 (Library)/Mvvm/ViewModelBase.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
 using Template10.Common;
 using Template10.Services.NavigationService;
@@ -10,11 +13,18 @@ namespace Template10.Mvvm
     // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-MVVM
     public abstract class ViewModelBase : BindableBase, INavigable
     {
+        private volatile bool isNavigatedTo;
+        private volatile bool isNavigatedFrom;
+
+        [JsonIgnore]
+        public bool IsNavigatedTo => isNavigatedTo;
+        [JsonIgnore]
+        public bool IsNavigatedFrom => isNavigatedFrom;
+
+        #region Implicit Implementation of INavigable
+
         public virtual void OnNavigatedTo(object parameter, NavigationMode mode, IDictionary<string, object> state) { /* nothing by default */ }
-        public virtual Task OnNavigatedFromAsync(IDictionary<string, object> state, bool suspending)
-        {
-			return Task.CompletedTask;
-		}
+        public virtual Task OnNavigatedFromAsync(IDictionary<string, object> state, bool suspending) => Task.CompletedTask;
         public virtual void OnNavigatingFrom(Services.NavigationService.NavigatingEventArgs args) { /* nothing by default */ }
 
         [JsonIgnore]
@@ -23,6 +33,44 @@ namespace Template10.Mvvm
         public IDispatcherWrapper Dispatcher { get; set; }
         [JsonIgnore]
         public IStateItems SessionState { get; set; }
-        
+
+        #endregion
+
+        #region Overrides of BindableBase
+
+        public override void RaisePropertyChanged([CallerMemberName]string propertyName = null)
+        {
+            if (!this.isNavigatedFrom)
+                base.RaisePropertyChanged(propertyName);
+        }
+
+        public override void RaisePropertyChanged<T>(Expression<Func<T>> propertyExpression)
+        {
+            if (!this.isNavigatedFrom)
+                base.RaisePropertyChanged(propertyExpression);
+        }
+
+        #endregion
+
+        #region Explicit Implementation of INavigable
+
+        void INavigable.OnNavigatedTo(object parameter, NavigationMode mode, IDictionary<string, object> state)
+        {
+            isNavigatedTo = true;
+            isNavigatedFrom = false;
+            OnNavigatedTo(parameter, mode, state);
+        }
+
+        void INavigable.OnNavigatingFrom(Services.NavigationService.NavigatingEventArgs args)
+        {
+            OnNavigatingFrom(args);
+            if (!args.Cancel)
+            {
+                isNavigatedTo = false;
+                isNavigatedFrom = true;
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Block PropertyChanged events on viewmodels that have been "navigated from".

In our app several tasks are started to load data from a server API and write the results into the view model. When user clicks on the back button and Template10 navigates to a different view, we sometimes can see strange crashes of our app - caused by the background tasks trying to write into view model properties that are bound to the view but where the view is no longer valid.

The changes from this commit will add two properties to the view model if the view has been "navigated to" and "navigated from". If the viewmodels "NavigatedFrom" method was called, the flag is set and every RaisePropertyChanged call will no longer raise the event.
