### PR TITLE
Fixed #551: Deserialize the navigation parameter.

### DIFF
--- a/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
+++ b/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
@@ -3,18 +3,18 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Sample.Views
 {
-	public sealed partial class SettingsPage : Page
-	{
-		public SettingsPage()
-		{
-			this.InitializeComponent();
-		}
+    public sealed partial class SettingsPage : Page
+    {
+        public SettingsPage()
+        {
+            this.InitializeComponent();
+        }
 
-		protected override void OnNavigatedTo(NavigationEventArgs e)
-		{
-			var index = Template10.Services.SerializationService.SerializationService
-				.Json.Deserialize<int>(e.Parameter?.ToString());
-			MyPivot.SelectedIndex = index;
-		}
-	}
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            var index = Template10.Services.SerializationService.SerializationService
+                .Json.Deserialize<int>(e.Parameter?.ToString());
+            MyPivot.SelectedIndex = index;
+        }
+    }
 }

--- a/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
+++ b/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
@@ -1,21 +1,20 @@
-﻿using Sample.ViewModels;
-using Windows.UI.Xaml.Controls;
+﻿using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
 namespace Sample.Views
 {
-    public sealed partial class SettingsPage : Page
-    {
-        public SettingsPage()
-        {
-            this.InitializeComponent();
-        }
+	public sealed partial class SettingsPage : Page
+	{
+		public SettingsPage()
+		{
+			this.InitializeComponent();
+		}
 
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            int index;
-            if (int.TryParse(e.Parameter?.ToString(), out index))
-                MyPivot.SelectedIndex = index;
-        }
-    }
+		protected override void OnNavigatedTo(NavigationEventArgs e)
+		{
+			var index = Template10.Services.SerializationService.SerializationService
+				.Json.Deserialize<int>(e.Parameter?.ToString());
+			MyPivot.SelectedIndex = index;
+		}
+	}
 }


### PR DESCRIPTION
This fixes #551 by deserializing the navigation parameter in the Page.OnNavigatedTo method.
