### PR TITLE
StringConverter: Use CurrentCulture if language is not specified

### DIFF
--- a/Template10 (Library)/Converters/StringFormatConverter.cs
+++ b/Template10 (Library)/Converters/StringFormatConverter.cs
@@ -11,6 +11,12 @@ namespace Template10.Converters
             var format = (parameter as string) ?? Format;
             if (format == null)
                 return value;
+            
+            if(string.IsNullOrWhiteSpace(language))
+            {
+                return string.Format(format, value);
+            }    
+                
             try
             {
                 var culture = new CultureInfo(language);


### PR DESCRIPTION
Current problem - introduced [here](https://github.com/Windows-XAML/Template10/issues/545)

Simple binding with the converter - without given any language:

```
            <TextBlock Margin="0,8,0,8" HorizontalAlignment="Center" FontSize="42" FontWeight="Bold" Text="{Binding MoneyBurndownCounter, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:C}'}" />
```

Inside the converter:

format: "{0:C}"
culture: ""
value: "0"

False behavior (currently)

"¤0.00"

Fixed behavior

"$0.00" (depending on the CurrentCulture of the system.
