### PR TITLE
small correction to T10_ViewModel.snippet

### DIFF
--- a/Snippets/T10_ViewModel.snippet
+++ b/Snippets/T10_ViewModel.snippet
@@ -46,7 +46,7 @@
         </Literal>
       </Declarations>
       <Code Language="csharp">
-        <![CDATA[public class $name$ViewModel : Mvvm.ViewModelBase
+        <![CDATA[public class $name$ViewModel : ViewModelBase
         {
         }]]>
       </Code>


### PR DESCRIPTION
Corrected the namespace of the ViewModel Namespace,
From 
`public class $name$ViewModel : Mvvm.ViewModelBase`

To 
`public class $name$ViewModel : ViewModelBase`

This will prevent a red squiggly line under Mvvm after using the snippet
