### PR TITLE
small correction to T10_PropertySetting.snippet 

### DIFF
--- a/Snippets/T10_PropertySetting.snippet
+++ b/Snippets/T10_PropertySetting.snippet
@@ -38,7 +38,7 @@
       <Code Language="csharp">
         <![CDATA[public $type$ $name$
         {
-            get { return $helper$.Read<$type$>(nameof($name$), default()); }
+            get { return $helper$.Read<$type$>(nameof($name$), default($type$)); }
             set { $helper$.Write(nameof($name$), value); }
         }]]>
       </Code>


### PR DESCRIPTION
I think line 41 of T10_PropertySetting.snippet should be:
 get { return $helper$.Read<$type$>(nameof($name$), default($type$)); } 
 instead of 
 get { return $helper$.Read<$type$>(nameof($name$), default()); } 
