### PR TITLE
Fixing bug in #610 and adding support NavigateFrom and NavigatingFrom 

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -60,6 +60,8 @@ namespace Template10.Common
         /// </summary>
         public virtual Services.NavigationService.INavigable ResolveForPage(Type page, NavigationService navigationService) => null;
 
+        public virtual Services.NavigationService.INavigable ResolveForPage(Page page, NavigationService navigationService) => null;
+
         #endregion
 
         public static new BootStrapper Current { get; private set; }

--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -60,7 +60,11 @@ namespace Template10.Common
         /// </summary>
         public virtual Services.NavigationService.INavigable ResolveForPage(Type page, NavigationService navigationService) => null;
 
-        public virtual Services.NavigationService.INavigable ResolveForPage(Page page, NavigationService navigationService) => null;
+        public virtual Services.NavigationService.INavigable ResolveForPage(Page page,
+            NavigationService navigationService)
+        {
+            return ResolveForPage(page.GetType(), navigationService);
+        }
 
         #endregion
 

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -68,7 +68,7 @@ namespace Template10.Services.NavigationService
             if (!(page.DataContext is INavigable) | page.DataContext == null)
             {
                 // to support dependency injection, but keeping it optional.
-                var viewModel = BootStrapper.Current.ResolveForPage(page.GetType(), this);
+                var viewModel = BootStrapper.Current.ResolveForPage(page, this);
                 if ((viewModel != null))
                 {
                     return viewModel;

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -63,6 +63,12 @@ namespace Template10.Services.NavigationService
             };
         }
 
+        // can be overriden in case the ViewModel is wrapped
+        protected virtual INavigable UnwrapNavigableFromDataContext(Page page)
+        {
+            return page.DataContext as INavigable;
+        }
+
         // before navigate (cancellable) 
         async Task<bool> NavigatingFromAsync(bool suspending)
         {
@@ -74,8 +80,8 @@ namespace Template10.Services.NavigationService
                 // force (x:bind) page bindings to update
                 XamlUtils.UpdateBindings(page);
 
-                // call navagable override (navigating)
-                var dataContext = page.DataContext as INavigable;
+                // call ViewModel
+                var dataContext = UnwrapNavigableFromDataContext(page);
                 if (dataContext != null)
                 {
                     dataContext.NavigationService = this;
@@ -104,7 +110,7 @@ namespace Template10.Services.NavigationService
             if (page != null)
             {
                 // call viewmodel
-                var dataContext = page.DataContext as INavigable;
+                var dataContext = UnwrapNavigableFromDataContext(page);
                 if (dataContext != null)
                 {
                     dataContext.NavigationService = this;
@@ -143,7 +149,7 @@ namespace Template10.Services.NavigationService
                 }
 
                 // call viewmodel
-                var dataContext = page.DataContext as INavigable;
+                var dataContext = UnwrapNavigableFromDataContext(page);
                 if (dataContext != null)
                 {
                     // prepare for state load

--- a/Template10 (Library)/Template10 (Library).csproj
+++ b/Template10 (Library)/Template10 (Library).csproj
@@ -16,6 +16,10 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -254,8 +258,8 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>call "$(ProjectDir)\Nuget\Build.cmd" "$(TargetDir)" "$(TargetName)" "$(ProjectDir)"
-call "$(SolutionDir)\Snippets\InstallSnippets.cmd"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This pull request extends the support to also encompase NavigateFrom and NavigatingFrom. 

Also, the overload of ResolveForPage is necessary to add a DataContext unwrapping to ResolveForPage. This existing ResolveForPage is only called with the page Type, while the new overload of ResolveForPage includes the actual Page object necessary when doing an unwrap.  
