### PR TITLE
Supporting Proxied/Wrapped ViewModels

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -58,6 +58,7 @@ namespace Template10.Common
         /// If a developer overrides this method, and leaves the DataContext of a page null, then BootStrapper
         /// will atttempt to fill the DataContext the return value of this method. 
         /// </summary>
+        [Obsolete("Use ResolveForPage(Page, NavigationService) instead")]
         public virtual Services.NavigationService.INavigable ResolveForPage(Type page, NavigationService navigationService) => null;
         
         /// <summary>

--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -64,10 +64,7 @@ namespace Template10.Common
         /// If a developer overrides this method, the developer can resolve DataContext or unwrap DataContext 
         /// available for the Page object when using a MVVM pattern that relies on a wrapped/porxy around ViewModels
         /// </summary>
-        public virtual Services.NavigationService.INavigable ResolveForPage(Page page, NavigationService navigationService)
-        {
-            return ResolveForPage(page.GetType(), navigationService);
-        }
+        public virtual Services.NavigationService.INavigable ResolveForPage(Page page, NavigationService navigationService) =>  ResolveForPage(page.GetType(), navigationService);
 
         #endregion
 

--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -59,6 +59,16 @@ namespace Template10.Common
         /// will atttempt to fill the DataContext the return value of this method. 
         /// </summary>
         public virtual Services.NavigationService.INavigable ResolveForPage(Type page, NavigationService navigationService) => null;
+        
+        /// <summary>
+        /// If a developer overrides this method, the developer can resolve DataContext or unwrap DataContext 
+        /// available for the Page object if using a MVVM pattern that relies on a wrapped/porxy around ViewModels
+        /// </summary>
+        public virtual Services.NavigationService.INavigable ResolveForPage(Page page,
+            NavigationService navigationService)
+        {
+            return ResolveForPage(page.GetType(), navigationService);
+        }
 
         #endregion
 

--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -62,10 +62,9 @@ namespace Template10.Common
         
         /// <summary>
         /// If a developer overrides this method, the developer can resolve DataContext or unwrap DataContext 
-        /// available for the Page object if using a MVVM pattern that relies on a wrapped/porxy around ViewModels
+        /// available for the Page object when using a MVVM pattern that relies on a wrapped/porxy around ViewModels
         /// </summary>
-        public virtual Services.NavigationService.INavigable ResolveForPage(Page page,
-            NavigationService navigationService)
+        public virtual Services.NavigationService.INavigable ResolveForPage(Page page, NavigationService navigationService)
         {
             return ResolveForPage(page.GetType(), navigationService);
         }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -84,7 +84,7 @@ namespace Template10.Services.NavigationService
                 {
                     return viewModel;
                 }
-                throw new ArgumentNullException();
+                throw new ArgumentNullException("Unable to Resolve For Page. No ViewModel could be found");
             }
             return (INavigable)page.DataContext;
         }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -73,6 +73,21 @@ namespace Template10.Services.NavigationService
                 }, 1);
             };
         }
+        
+        private INavigable NavigableDataContext(Page page)
+        {
+            if (!(page.DataContext is INavigable) | page.DataContext == null)
+            {
+                // to support dependency injection, but keeping it optional.
+                var viewModel = BootStrapper.Current.ResolveForPage(page, this);
+                if ((viewModel != null))
+                {
+                    return viewModel;
+                }
+                throw new ArgumentNullException();
+            }
+            return (INavigable)page.DataContext;
+        }
 
         // before navigate (cancellable)
         async Task<bool> NavigatingFromAsync(bool suspending, NavigationMode mode)
@@ -86,7 +101,7 @@ namespace Template10.Services.NavigationService
                 XamlUtils.UpdateBindings(page);
 
                 // call navagable override (navigating)
-                var dataContext = page.DataContext as INavigable;
+                var dataContext = NavigableDataContext(page);
                 if (dataContext != null)
                 {
                     dataContext.NavigationService = this;
@@ -115,7 +130,7 @@ namespace Template10.Services.NavigationService
             if (page != null)
             {
                 // call viewmodel
-                var dataContext = page.DataContext as INavigable;
+                var dataContext = NavigableDataContext(page);
                 if (dataContext != null)
                 {
                     dataContext.NavigationService = this;
@@ -145,16 +160,8 @@ namespace Template10.Services.NavigationService
                     pageState?.Clear();
                 }
 
-                if (!(page.DataContext is INavigable) | page.DataContext == null)
-                {
-                    // to support dependency injection, but keeping it optional.
-                    var viewmodel = BootStrapper.Current.ResolveForPage(page.GetType(), this);
-                    if (viewmodel != null)
-                        page.DataContext = viewmodel;
-                }
-
-                // call viewmodel
-                var dataContext = page.DataContext as INavigable;
+                var dataContext = NavigableDataContext(page);
+                
                 if (dataContext != null)
                 {
                     // prepare for state load

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -84,7 +84,6 @@ namespace Template10.Services.NavigationService
                 {
                     return viewModel;
                 }
-                throw new ArgumentNullException("Unable to Resolve For Page. No ViewModel could be found");
             }
             return (INavigable)page.DataContext;
         }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -74,7 +74,7 @@ namespace Template10.Services.NavigationService
             };
         }
         
-        private INavigable NavigableDataContext(Page page)
+        private INavigable ResolveForPage(Page page)
         {
             if (!(page.DataContext is INavigable) | page.DataContext == null)
             {
@@ -101,7 +101,7 @@ namespace Template10.Services.NavigationService
                 XamlUtils.UpdateBindings(page);
 
                 // call navagable override (navigating)
-                var dataContext = NavigableDataContext(page);
+                var dataContext = ResolveForPage(page);
                 if (dataContext != null)
                 {
                     dataContext.NavigationService = this;
@@ -130,7 +130,7 @@ namespace Template10.Services.NavigationService
             if (page != null)
             {
                 // call viewmodel
-                var dataContext = NavigableDataContext(page);
+                var dataContext = ResolveForPage(page);
                 if (dataContext != null)
                 {
                     dataContext.NavigationService = this;
@@ -160,7 +160,7 @@ namespace Template10.Services.NavigationService
                     pageState?.Clear();
                 }
 
-                var dataContext = NavigableDataContext(page);
+                var dataContext = ResolveForPage(page);
                 
                 if (dataContext != null)
                 {


### PR DESCRIPTION
Please read this carefully this before you dismiss this PR? The comments, I got the previous two times I tried left me with the feeling that we are not entirely on the same page, so I try once more.

From our conversation I get sense is that the idea of wrapped/proxied ViewModels feels unfamiliar. I get that; nevertheless a MVVM pattern using this approach such as that supported by Assisticant (https://www.nuget.org/packages/Assisticant/) have been downloaded ~3000 times so “yikes”, there are other “crazy”, “complicated” people out there ;-)
  
For me this pattern helps make ViewModels cleaner. I don’t like complexity either.

The changes proposed are:

**NavigationService.cs:**
#590 addressed NavigateToAsync only. However, I see that `page.DataContext as INavigable` since yesterday is now also used in NavigateFromAsync and NavigatedFromAsync.

I’m glad we agree that this is an improvement over checking DataContext for null, as all three methods are in fact assuming INavigable to work as intended. The new code is an improvement, but it is still insufficient for dealing with wrapped ViewModels. 

Using ResolveForPage is indeed the right approach and I do apologies that my first suggestion did not recognize this. Now, let’s make sure that all three methods do in fact use ResolveForPage to deal with situations where DataContext is not INavigable. Currently only NativateToAsync does. The two others just ignore any further action if DataContext is not INavigable. 

Because all three methods need to get hold of the right INavigable DataContext/ViewModel, I think the best approach is to create one single private method called “ResolveForPage(Page page)” in NavigationService.cs. The rational is reducing complexity – i.e. write the code once, not thrice. 

Please notice that I’m passed the **Page object** and not just the Type of the page to ResolveForPage. There is an important reason for that, which leads me to the changes proposed to Bootstrapper.cs.

**Bootstrapper.cs.**

Here I propose to overload the ResolveForPage with a new method signature that accepts the **Page object**: `public virtual INavigable ResolveForPage(Page page, NavigationService navigationService)`

In the PR the new overloaded ResolveForPage gets the Type of the page and then passes the Type on to the original ResolveForPage method. This is just to ensure that any current implementation that might be overriding the original ResolveForPage(Type type…) is unaffected by the change. 

But why overload the ResolveForPage? Because, this new overloaded ResolveForPage(Page page…) is what enables anyone working with wrapped ViewModels gain access to the Page object so that they can write code to upwrap the DataContext in order to expose the inner object that satisfy the INavigable assumption needed for the NavigationService. The existing ResoveForPage(Type type…) is insufficient for this purpose. 

Just as an example: using Assisticant with the proposed modifications would look something like this:

```
public class BootStrapperEx : BootStrapper
{

    public override INavigable ResolveForPage(Page page, NavigationService navigationService)
    {
        return ForView.Unwrap<dynamic>(page.DataContext) as INavigable;
    }

}
```

I’ve tested it and this works as intended. And just as importantly it opens Template10 to the exotic bread of developers who like to wrap their ViewModels. We are people too you know ;-)

Oh and finally, I don’t see this breaking anything.

Thank you for your understanding.
