### PR TITLE
HamburgerMenu should only navigate when all NavButtons have been loaded

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -84,6 +84,9 @@ namespace Template10.Controls
                     if (!any)
                         // this is the default color if the user supplies none
                         AccentColor = Colors.DarkOrange;
+
+                    if (NavButtonCount == 0)
+                        _areNavButtonsLoaded = true;
                 };
             }
         }
@@ -447,8 +450,8 @@ namespace Template10.Controls
             _navButtons.Where(x => x.Value != value)
                 .ForEach(x => { x.Value.IsChecked = false; });
 
-            // navigate
-            if (value?.PageType != null)
+            // navigate only when all navigation buttons have been loaded
+            if (_areNavButtonsLoaded && value?.PageType != null)
             {
                 if (NavigationService.Navigate(value.PageType, value?.PageParameter, value?.NavigationTransitionInfo))
                 {
@@ -683,6 +686,13 @@ namespace Template10.Controls
             var i = r.DataContext as HamburgerButtonInfo;
             _navButtons.Add(r, i);
             HighlightCorrectButton();
+
+            if (!_areNavButtonsLoaded)
+            {
+                _navButtonsLoadedCounter++;
+                if (_navButtonsLoadedCounter >= NavButtonCount)
+                    _areNavButtonsLoaded = true;
+            }
         }
 
         private void NavButton_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
@@ -725,6 +735,13 @@ namespace Template10.Controls
         {
             _SecondaryButtonStackPanel = sender as StackPanel;
         }
+
+        private int NavButtonCount
+        {
+            get { return PrimaryButtons.Count + SecondaryButtons.Count; }
+        }
+        private bool _areNavButtonsLoaded = false;
+        private int _navButtonsLoadedCounter = 0;
 
         bool _insideOperation = false;
 
@@ -788,7 +805,7 @@ namespace Template10.Controls
 
         public bool AutoHighlightCorrectButton
         {
-            get { return true; /*(bool)GetValue(AutoHighlightCorrectButtonProperty);*/ }
+            get { return (bool)GetValue(AutoHighlightCorrectButtonProperty); }
             set { SetValue(AutoHighlightCorrectButtonProperty, value); }
         }
         public static readonly DependencyProperty AutoHighlightCorrectButtonProperty =


### PR DESCRIPTION
Issue #628
Every time a NavigationButton in HamburgerMenu has been loaded "HighlightCorrectButton" is called. Within this method "SetSelected" is called with the correct button, which then fires NavigationService.Navigate with the corresponding page as parameter.
This causes a problem at app start when a parameter is passed to the first page:

```
public override Task OnStartAsync(StartKind startKind, IActivatedEventArgs args)
{
    NavigationService.Navigate(typeof (Views.MainPage), "Test");
    return Task.CompletedTask;
}
```

The first navigation works fine. But after OnStartAsync the HamburgerMenu gets loaded and "HighlightCorrectButton" gets fired, which then causes another navigation to the same page, but with a parameter of null.

To fix this the HamburgerMenu should only navigate once all NavigationButtons have been loaded. If not all buttons have been loaded the correct button will still get highlighted, but no additional navigation will be fired.
