### PR TITLE
HamburgerButtonInfo: ToolTipService.ToolTip support

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -62,7 +62,8 @@
                              IsChecked="{Binding IsChecked, Mode=TwoWay}"
                              IsEnabled="{Binding IsEnabled, Mode=TwoWay}" Loaded="NavButton_Loaded"
                              RightTapped="NavButton_RightTapped" Tag="{x:Bind Content}"
-                             Tapped="NavButton_Tapped" Visibility="{Binding Visibility, Mode=TwoWay}">
+                             Tapped="NavButton_Tapped" Visibility="{Binding Visibility, Mode=TwoWay}"
+                             ToolTipService.ToolTip="{Binding Path=(ToolTipService.ToolTip)}">
                     <RadioButton.Template>
                         <ControlTemplate TargetType="RadioButton">
                             <ToggleButton MinWidth="48" MinHeight="48" MaxWidth="{TemplateBinding MaxWidth}"


### PR DESCRIPTION
#580

After this fix, you can now add ToolTip to HamburgerButtonInfo:

```
<Controls:HamburgerButtonInfo ClearHistory="True" PageType="views:MainPage" ToolTipService.ToolTip="Home">... 
```

Also works with data binding:

```
<Controls:HamburgerButtonInfo ClearHistory="True" PageType="views:MainPage" ToolTipService.ToolTip="{Binding Name}">... 
```
