### PR TITLE
Fix BackButton Issue (Related to issue #567)

### DIFF
--- a/Samples/MasterDetail/Views/MainPage.xaml
+++ b/Samples/MasterDetail/Views/MainPage.xaml
@@ -54,6 +54,7 @@
                         <AdaptiveTrigger MinWindowWidth="{StaticResource NormalMinWidth}" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
+                        <Setter Target="BackButton.IsEnabled" Value="False" />
                         <Setter Target="MailDetail.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>
@@ -62,6 +63,7 @@
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideMinWidth}" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
+                        <Setter Target="BackButton.IsEnabled" Value="False" />
                         <Setter Target="MailDetail.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>


### PR DESCRIPTION
If you have a BackButton in TitleBar (or hardware button), it will still trigger GoToStateAction ListVisualState when you go back to VisualStateNormal or Wide from DetailVisualState.

This will make sure that BackButton is Disabled unless you're in VisualStateNarrow(DetailVisualState)
