### PR TITLE
Remove obsolete PaneOpen event

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -26,8 +26,6 @@ namespace Template10.Controls
     [ContentProperty(Name = nameof(PrimaryButtons))]
     public sealed partial class HamburgerMenu : UserControl
     {
-        [Obsolete("Fixing naming inconsistency; use HamburgerMenu.PaneOpened", true)]
-        public event EventHandler PaneOpen;
         public event EventHandler PaneOpened;
         public event EventHandler PaneClosed;
         public event EventHandler<ChangedEventArgs<HamburgerButtonInfo>> SelectedChanged;
@@ -75,7 +73,6 @@ namespace Template10.Controls
                     if ((d as SplitView).IsPaneOpen)
                     {
                         PaneOpened?.Invoke(ShellSplitView, EventArgs.Empty);
-                        PaneOpen?.Invoke(ShellSplitView, EventArgs.Empty);
                     }
                     else
                         PaneClosed?.Invoke(ShellSplitView, EventArgs.Empty);


### PR DESCRIPTION
Remove obsolete code - this is a breaking change but easy to fix.
