### PR TITLE
Fixes the momentary flash of RootGrid background brush when switching…

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -182,7 +182,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid x:Name="RootGrid" Background="{x:Bind HamburgerBackground, FallbackValue=DarkRed, Mode=OneWay}">
+    <Grid x:Name="RootGrid">
 
         <VisualStateManager.VisualStateGroups>
 
@@ -362,7 +362,10 @@
 
         </SplitView>
 
-        <Grid Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Top"
+        <Grid x:Name="HamburgerButtonGrid" Grid.Row="0"
+              Width="{x:Bind HamburgerButtonGridWidth, Mode=OneWay}"
+              Background="{x:Bind HamburgerBackground, FallbackValue=DarkRed, Mode=OneWay}"
+              Opacity="0.95" HorizontalAlignment="Left" VerticalAlignment="Top"
               Visibility="{x:Bind HamburgerButtonVisibility, Mode=OneWay}">
             <Button x:Name="HamburgerButton"
                     Background="{x:Bind HamburgerBackground, FallbackValue=DarkRed, Mode=OneWay}"

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -73,6 +73,7 @@ namespace Template10.Controls
                     if ((d as SplitView).IsPaneOpen)
                     {
                         PaneOpened?.Invoke(ShellSplitView, EventArgs.Empty);
+                        HamburgerButtonGridWidth = (ShellSplitView.DisplayMode == SplitViewDisplayMode.CompactInline) ? PaneWidth : 48;
                     }
                     else
                         PaneClosed?.Invoke(ShellSplitView, EventArgs.Empty);
@@ -122,6 +123,7 @@ namespace Template10.Controls
             var m = (SplitViewDisplayMode)e.NewValue;
             if (h.ShellSplitView.DisplayMode != m)
                 h.ShellSplitView.DisplayMode = m;
+            h.HamburgerButtonGridWidth = (h.ShellSplitView.DisplayMode == SplitViewDisplayMode.CompactInline)? h.PaneWidth : 48;
         }
 
         internal void HighlightCorrectButton(Type pageType = null, object pageParam = null)
@@ -513,6 +515,7 @@ namespace Template10.Controls
                 if (value)
                 {
                     ShellSplitView.IsPaneOpen = true;
+                    HamburgerButtonGridWidth = (ShellSplitView.DisplayMode == SplitViewDisplayMode.CompactInline) ? PaneWidth : 48;
                 }
                 else
                 {
@@ -523,6 +526,7 @@ namespace Template10.Controls
                         ShellSplitView.IsPaneOpen = false;
                     else if (ShellSplitView.DisplayMode == SplitViewDisplayMode.CompactInline && ShellSplitView.IsPaneOpen)
                         ShellSplitView.IsPaneOpen = false;
+                    HamburgerButtonGridWidth = 48;
                 }
             }
         }
@@ -694,6 +698,33 @@ namespace Template10.Controls
         public static readonly DependencyProperty HeaderContentProperty =
             DependencyProperty.Register(nameof(HeaderContent), typeof(UIElement),
                 typeof(HamburgerMenu), new PropertyMetadata(null, (d, e) => Changed(nameof(HeaderContent), e)));
+
+
+        /// <summary>
+        /// HamburgerButtonGridWidth represents the width of a Grid containing 
+        /// the HamburgerMenu button.
+        /// </summary>
+        /// <remarks>
+        /// The Grid width must remain the same size as the HamburgerMenu button (48px wide)
+        /// except when (ShellSplitView.DisplayMode == SplitViewDisplayMode.CompactInline) &&
+        /// (ShellSplitView.IsPaneOpen == true), in which case it must adjust to the width of 
+        /// PaneWidth to fill in the gap between HamburgerMenu button and PageHeader.
+        /// Previous implementation applied the HamburgerMenu background brush 
+        /// to the RootGrid control but this rather easy approach had its drawback of momentarily
+        /// showing the page-wide RootGrid background while changing the dark/light theme (as noticeable flash 
+        /// for bright colors such as variants of prime colors). With this adaptive 
+        /// HamburgerButtonGridWidth, the area is just a narrow strip (as opposed to page-wide 
+        /// RootGrid control) and the the flashing problem is virtually non-existent.
+        /// </remarks>
+ 
+        public double HamburgerButtonGridWidth
+        {
+            get { return (double)GetValue(HamburgerButtonGridWidthProperty); }
+            set { SetValue(HamburgerButtonGridWidthProperty, value); }
+        }
+        public static readonly DependencyProperty HamburgerButtonGridWidthProperty =
+            DependencyProperty.Register(nameof(HamburgerButtonGridWidth), typeof(double),
+               typeof(HamburgerMenu), new PropertyMetadata(48d, (d, e) => Changed(nameof(HamburgerButtonGridWidth), e)));
 
         #endregion
 


### PR DESCRIPTION
Fixes the momentary flash of RootGrid background brush when switching dark/light themes.

Further info from [Line 703](https://github.com/Windows-XAML/Template10/pull/765/files#diff-ae3950648be7d73717351e18b582c74dR703) in source code as summary/remark documentation.
