### PR TITLE
Added Target property for FocusAction

### DIFF
--- a/Template10 (Library)/Behaviors/FocusAction.cs
+++ b/Template10 (Library)/Behaviors/FocusAction.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xaml.Interactivity;
+using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -8,10 +9,35 @@ namespace Template10.Behaviors
     {
         public object Execute(object sender, object parameter)
         {
-            var ui = sender as Control;
-            if (ui != null)
-                ui.Focus(FocusState.Programmatic);
-            return null;
+         var ui = (Target == null ? sender : Target) as Control;
+         if (ui != null)
+            ui.Focus(FocusState.Programmatic);
+         return null;
         }
-    }
+
+      /// 
+      /// Backing storage for the Target property
+      /// 
+      public static readonly DependencyProperty TargetProperty = DependencyProperty.Register(
+          "Target",
+          typeof(Control),
+          typeof(FocusAction),
+          new PropertyMetadata(null));
+
+      /// 
+      /// Control to set the focus to.
+      /// 
+      public Control Target
+      {
+         get
+         {
+            return (Control) base.GetValue(TargetProperty);
+         }
+
+         set
+         {
+            base.SetValue(TargetProperty, value);
+         }
+      }
+   }
 }


### PR DESCRIPTION
Using the Target property you can set the focus to another control.
Sample:
`<TextBox x:Name="tb">
         <Interactivity:Interaction.Behaviors>
            <Behaviors:KeyBehavior Key="Enter">
                <Behaviors:FocusAction Target="{Binding ElementName=pb2}"/>
            </Behaviors:KeyBehavior>
         </Interactivity:Interaction.Behaviors>
    </TextBox>
`
