### PR TITLE
Add ClearPropertyChanged method to reset PropertyChanged event

### DIFF
--- a/Template10 (Library)/Mvvm/BindableBase.cs
+++ b/Template10 (Library)/Mvvm/BindableBase.cs
@@ -13,6 +13,11 @@ namespace Template10.Mvvm
     {
         public event PropertyChangedEventHandler PropertyChanged;
 
+        protected void ClearPropertyChanged()
+        {
+            PropertyChanged = null;
+        }
+
         public virtual bool Set<T>(ref T storage, T value, [CallerMemberName]string propertyName = null)
         {
             if (object.Equals(storage, value))

--- a/Template10 (Library)/Mvvm/DependencyBindableBase.cs
+++ b/Template10 (Library)/Mvvm/DependencyBindableBase.cs
@@ -12,6 +12,11 @@ namespace Template10.Mvvm
     {
         public event PropertyChangedEventHandler PropertyChanged;
 
+        protected void ClearPropertyChanged()
+        {
+            PropertyChanged = null;
+        }
+
         public virtual bool Set<T>(ref T storage, T value, [CallerMemberName]string propertyName = null)
         {
             if (object.Equals(storage, value))


### PR DESCRIPTION
Add ClearPropertyChanged method to reset PropertyChanged event. We need this method to be able to remove all subscriptions on PropertyChanged event. This helps us to prevent memory leaks.
