### PR TITLE
Check for UI thread access instead to catching COMException and retry

### DIFF
--- a/Template10 (Library)/Mvvm/DependencyBindableBase.cs
+++ b/Template10 (Library)/Mvvm/DependencyBindableBase.cs
@@ -12,39 +12,46 @@ namespace Template10.Mvvm
     {
         public event PropertyChangedEventHandler PropertyChanged;
 
+        public virtual bool Set<T>(ref T storage, T value, [CallerMemberName]string propertyName = null)
+        {
+            if (object.Equals(storage, value))
+                return false;
+
+            storage = value;
+            this.RaisePropertyChanged(propertyName);
+            return true;
+        }
+
         public virtual void RaisePropertyChanged([CallerMemberName]string propertyName = null)
         {
             if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
                 return;
 
             var handler = PropertyChanged;
-            //if is not null
             if (!object.Equals(handler, null))
             {
                 var args = new PropertyChangedEventArgs(propertyName);
-                try
+                var dispatcher = WindowWrapper.Current().Dispatcher;
+                if (dispatcher.HasThreadAccess())
                 {
-                    handler.Invoke(this, args);
+                    try
+                    {
+                        handler.Invoke(this, args);
+                    }
+                    catch
+                    {
+                        dispatcher.Dispatch(() => handler.Invoke(this, args));
+                    }
                 }
-                catch
+                else
                 {
-                    WindowWrapper.Current().Dispatcher.Dispatch(() => handler.Invoke(this, args));
+                    dispatcher.Dispatch(() => handler.Invoke(this, args));
                 }
             }
         }
 
-        public virtual bool Set<T>(ref T storage, T value, [CallerMemberName]string propertyName = null)
-        {
-            if (object.Equals(storage, value))
-                return false;
-            storage = value;
-            this.RaisePropertyChanged(propertyName);
-            return true;
-        }
-
         public virtual bool Set<T>(Expression<Func<T>> propertyExpression, ref T field, T newValue)
         {
-            //if is equal 
             if (object.Equals(field, newValue))
             {
                 return false;
@@ -61,21 +68,27 @@ namespace Template10.Mvvm
                 return;
 
             var handler = this.PropertyChanged;
-            //if is not null
             if (!object.Equals(handler, null))
             {
                 var propertyName = ExpressionUtils.GetPropertyName(propertyExpression);
-
                 if (!object.Equals(propertyName, null))
                 {
                     var args = new PropertyChangedEventArgs(propertyName);
-                    try
+                    var dispatcher = WindowWrapper.Current().Dispatcher;
+                    if (dispatcher.HasThreadAccess())
                     {
-                        handler.Invoke(this, args);
+                        try
+                        {
+                            handler.Invoke(this, args);
+                        }
+                        catch
+                        {
+                            dispatcher.Dispatch(() => handler.Invoke(this, args));
+                        }
                     }
-                    catch
+                    else
                     {
-                        WindowWrapper.Current().Dispatcher.Dispatch(() => handler.Invoke(this, args));
+                        dispatcher.Dispatch(() => handler.Invoke(this, args));
                     }
                 }
             }


### PR DESCRIPTION
When RaisePropertyChanged (or Set) methods in BindableBase and DependencyBindableBase are called from outside the UI threads, usually a COMException is thrown when the event fires. This exception is caught and the event is fired again from UI Thread using the Dispatcher.

Problem is that when I have two subscribers and the COMException is thrown on the second, the first one runs and is called again for the second call. So catching the Exception can only be a workaround.

The change from this PR use Dispatcher to check if we are on the UI thread (Dispatcher.IsThreadAccess()) and if we are not, it does not try to fire the event without switching to the UI thread before.

What to you think?
Please review.

Also moved the first Set method before the first RaisePropertyChanged method to have the "string" and the "Expression" overloads grouped and in the same order.
