### PR TITLE
Improve serialization of navigation parameters

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -236,13 +236,26 @@ namespace Template10.Controls
             {
                 pageParam = NavigationService.CurrentPageParam;
             }
-            else if (pageParam.ToString().StartsWith("{"))
+            else
             {
-                try
+                string pageParamString = pageParam.ToString();
+                if (pageParamString.StartsWith("{"))
                 {
-                    pageParam = NavigationService.FrameFacade.SerializationService.Deserialize(pageParam.ToString());
+                    try
+                    {
+                        if (string.Equals(pageParamString, NavigationService.LastNavigationParameterString))
+                        {
+                            pageParam = NavigationService.LastNavigationParameter;
+                        }
+                        else
+                        {
+                            pageParam = NavigationService.FrameFacade.SerializationService.Deserialize(pageParamString);
+                        }
+                    }
+                    catch
+                    {
+                    }
                 }
-                catch { }
             }
 
             // add parameter match

--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -228,7 +228,15 @@ namespace Template10.Services.NavigationService
             DebugWrite();
 
             CurrentPageType = e.SourcePageType;
-            CurrentPageParam = SerializationService.Deserialize(e.Parameter?.ToString());
+            string parameterString = e.Parameter?.ToString();
+            if (string.Equals(parameterString, NavigationService.LastNavigationParameterString))
+            {
+                CurrentPageParam = NavigationService.LastNavigationParameter;
+            }
+            else
+            {
+                CurrentPageParam = SerializationService.Deserialize(parameterString);
+            }
             var args = new NavigatedEventArgs(e, Content as Page);
             if (NavigationModeHint != NavigationMode.New)
                 args.NavigationMode = NavigationModeHint;
@@ -252,7 +260,15 @@ namespace Template10.Services.NavigationService
             object parameter = null;
             try
             {
-                parameter = SerializationService.Deserialize(e.Parameter?.ToString());
+                string parameterString = e.Parameter?.ToString();
+                if (string.Equals(parameterString, NavigationService.LastNavigationParameterString))
+                {
+                    parameter = NavigationService.LastNavigationParameter;
+                }
+                else
+                {
+                    parameter = SerializationService.Deserialize(parameterString);
+                }
             }
             catch (Exception ex)
             {

--- a/Template10 (Library)/Services/NavigationService/INavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/INavigationService.cs
@@ -45,5 +45,8 @@ namespace Template10.Services.NavigationService
 
         Frame Frame { get; }
         FrameFacade FrameFacade { get; }
+
+        object LastNavigationParameter { get; }
+        string LastNavigationParameterString { get; }
     }
 }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -22,8 +22,8 @@ namespace Template10.Services.NavigationService
         FrameFacade FrameFacadeInternal { get; set; }
         public FrameFacade FrameFacade => FrameFacadeInternal;
         public Frame Frame => FrameFacade.Frame;
-        internal object LastNavigationParameter { get; set; }
-        internal string LastNavigationParameterString { get; set; }
+        public object LastNavigationParameter { get; private set; }
+        public string LastNavigationParameterString { get; private set; }
         string LastNavigationType { get; set; }
         public object Content => Frame.Content;
 
@@ -404,13 +404,6 @@ namespace Template10.Services.NavigationService
 
         public Type CurrentPageType => FrameFacadeInternal.CurrentPageType;
         public object CurrentPageParam => FrameFacadeInternal.CurrentPageParam;
-
-        #region Explicit Implementation of INavigationService
-
-        object INavigationService.LastNavigationParameter => LastNavigationParameter;
-        string INavigationService.LastNavigationParameterString => LastNavigationParameterString;
-
-        #endregion
     }
 }
 

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -22,8 +22,8 @@ namespace Template10.Services.NavigationService
         FrameFacade FrameFacadeInternal { get; set; }
         public FrameFacade FrameFacade => FrameFacadeInternal;
         public Frame Frame => FrameFacade.Frame;
-        object LastNavigationParameter { get; set; }
-        object LastNavigationParameterString { get; set; }
+        internal object LastNavigationParameter { get; set; }
+        internal string LastNavigationParameterString { get; set; }
         string LastNavigationType { get; set; }
         public object Content => Frame.Content;
 
@@ -404,6 +404,13 @@ namespace Template10.Services.NavigationService
 
         public Type CurrentPageType => FrameFacadeInternal.CurrentPageType;
         public object CurrentPageParam => FrameFacadeInternal.CurrentPageParam;
+
+        #region Explicit Implementation of INavigationService
+
+        object INavigationService.LastNavigationParameter => LastNavigationParameter;
+        string INavigationService.LastNavigationParameterString => LastNavigationParameterString;
+
+        #endregion
     }
 }
 


### PR DESCRIPTION
Improve serialization of navigation parameters by also saving the serialized string and compare the string instead of serialize the saved parameter again. This might cause minor side effects when complex objects used as parameter are modified later, but IMHO complex parameter objects should only used to transfer parameters and never be modified.
