### PR TITLE
Added Feedback Hub integration helper

### DIFF
--- a/Template10 (Library)/Template10 (Library).csproj
+++ b/Template10 (Library)/Template10 (Library).csproj
@@ -199,6 +199,7 @@
     <Compile Include="Utils\ColorUtils.cs" />
     <Compile Include="Utils\DeviceUtils.cs" />
     <Compile Include="Utils\ExpressionUtils.cs" />
+    <Compile Include="Utils\FeedbackUtils.cs" />
     <Compile Include="Utils\MonitorUtils.cs" />
     <Compile Include="Utils\IEnumerableUtils.cs" />
     <Compile Include="Utils\Template10Utils.cs" />
@@ -255,6 +256,12 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <SDKReference Include="Microsoft.Services.Store.Engagement, Version=10.0">
+      <Name>Microsoft Store Engagement SDK</Name>
+    </SDKReference>
+    <SDKReference Include="Microsoft.VCLibs, Version=14.0">
+      <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
+    </SDKReference>
     <SDKReference Include="WindowsMobile, Version=10.0.10240.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>

--- a/Template10 (Library)/Utils/FeedbackUtils.cs
+++ b/Template10 (Library)/Utils/FeedbackUtils.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.Services.Store.Engagement;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+
+namespace Template10.Utils
+{
+    /// <summary>
+    /// Provides properties and methods that allow access to the Feedback Hub on supported clients.
+    /// </summary>
+    /// <remarks>
+    /// This class is useful only on systems running Windows 10 build 14291 and higher.
+    /// </remarks>
+    public class FeedbackUtils
+    {
+        private static FeedbackUtils _current = new FeedbackUtils();
+
+        /// <summary>
+        /// Allows access to feedback-related properties and methods.
+        /// </summary>
+        public static FeedbackUtils Current
+        {
+            get
+            {
+                return _current;
+            }
+            private set
+            {
+                _current = value;
+            }
+        }
+
+        private FeedbackUtils()
+        {
+            Current = this;
+        }
+
+        /// <summary>
+        /// Returns Visibility.Visible when this functionality is supported.
+        /// </summary>
+        public Visibility _feedbackVisibility
+        {
+            get
+            {
+                if (Feedback.IsSupported)
+                    return Visibility.Visible;
+                return Visibility.Collapsed;
+            }
+        }
+
+        /// <summary>
+        /// Opens the Feedback Hub to send feedback.
+        /// </summary>
+        /// <returns>Boolean (async)</returns>
+        /// <exception cref="NotSupportedException">Thrown when the current device does not include the Feedback Hub.</exception>
+        public async Task<bool> SendFeedbackAsync()
+        {
+            if (!Feedback.IsSupported)
+                throw new NotSupportedException("Feedback Hub integration is not supported on this system.");
+            return await Feedback.LaunchFeedbackAsync();
+        }
+
+        /// <summary>
+        /// Opens the Feedback Hub to send feedback, providing some context for the developer.
+        /// </summary>
+        /// <param name="context">Context for the feedback</param>
+        /// <returns>Boolean (async)</returns>
+        /// <exception cref="NotSupportedException">Thrown when the current device does not include Feedback Hub.</exception>
+        public async Task<bool> SendFeedbackAsync(Dictionary<string, string> context)
+        {
+            if (!Feedback.IsSupported)
+                throw new NotSupportedException("Feedback Hub integration is not supported on this system");
+            return await Feedback.LaunchFeedbackAsync(context);
+        }
+    }
+}


### PR DESCRIPTION
I thought this would make a nice addition to Template 10. The new Monetization SDK adds support for the new feedback for developers system, which is absolutely wicked. So, since Template 10's job is to make the developer's life easier, I thought adding a helper utility for the Feedback Hub integration would be awesome. Not many additions, but here's the major stuff:
- Added the Store Engagement SDK to the library
- Added a Feedback utility to the Nuget library, which handles the integration.
