### PR TITLE
Force visual state for previous toggle button when selection is changed

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -294,6 +294,15 @@ namespace Template10.Controls
             {
                 previous.IsChecked = false;
                 previous.RaiseUnselected();
+
+                // Workaround for visual state of ToggleButton not reset correctly
+                var fwe = LoadedNavButtons.Where(x => x.HamburgerButtonInfo == previous)
+                    .Select(x => x.FrameworkElement)
+                    .FirstOrDefault() as Control;
+                if (fwe != null)
+                {
+                    VisualStateManager.GoToState(fwe, "Normal", true);
+                }
             }
 
             // navigate only when all navigation buttons have been loaded


### PR DESCRIPTION
Sometimes (mostly after the second change), ToggleButton in hamburger menu stay at the wrong visual state and are still shown as checked. As a workaround, with this commit the visual state for the previous toggle button is set to "Normal" when the selection is changed. This fixes the problem here
