### PR TITLE
PR fixes ControlTemplate visual states to avoid visual anomalies when…

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
@@ -453,5 +453,24 @@ namespace Template10.Controls
                 item.Value.Invoke(e);
             }
         }
+
+        public bool IsSettingToNormalVisualState
+        {
+            get { return (bool)GetValue(SetToNormalVisualStateProperty); }
+            set { SetValue(SetToNormalVisualStateProperty, value); }
+        }
+        public static readonly DependencyProperty SetToNormalVisualStateProperty =
+            DependencyProperty.Register(nameof(IsSettingToNormalVisualState), typeof(bool),
+        typeof(HamburgerMenu), new PropertyMetadata(false, async (d, e) => {
+
+            Changed(nameof(IsSettingToNormalVisualState), e);
+
+            if ((bool)e.NewValue)
+            { 
+                // If set to Normal visual state, persist it for sometime and negate it.
+                await Task.Delay(50);
+                (d as HamburgerMenu).IsSettingToNormalVisualState = false;
+            }
+        }));
     }
 }

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -115,12 +115,24 @@
                             <Grid x:Name="RootGrid"
                                   Width="{Binding PaneWidth, ElementName=ThisPage}"
                                   Background="Transparent">
+<!--
+Facilitates initialization of style visual state when the theme is changed during runtime.
+Setting the DP IsSettingToNormalVisualState = true in codebehind will set the visual state to Normal.                              
+-->
+                                <Interactivity:Interaction.Behaviors>
+                                    <Core:DataTriggerBehavior Binding="{Binding IsSettingToNormalVisualState, ElementName=ThisPage}" Value="True">
+                                        <Core:GoToStateAction StateName="Indeterminate" />
+                                    </Core:DataTriggerBehavior>
+                                </Interactivity:Interaction.Behaviors>
+
+
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates" CurrentStateChanged="NavButton_VisualStateChanged">
                                         <VisualState x:Name="Normal">
                                             <VisualState.Setters>
                                                 <Setter Target="ContentPresenter.Foreground" Value="{Binding NavButtonForeground, ElementName=ThisPage}" />
                                                 <Setter Target="ContentPresenter.Background" Value="{Binding NavButtonBackground, ElementName=ThisPage}" />
+                                                <Setter Target="Indicator.Visibility" Value="Collapsed" />
                                             </VisualState.Setters>
                                             <!--<Storyboard>
                                                 <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
@@ -130,6 +142,7 @@
                                             <VisualState.Setters>
                                                 <Setter Target="ContentPresenter.Foreground" Value="{Binding NavButtonHoverForeground, ElementName=ThisPage}" />
                                                 <Setter Target="ContentPresenter.Background" Value="{Binding NavButtonHoverBackground, ElementName=ThisPage}" />
+                                                <Setter Target="Indicator.Visibility" Value="Collapsed" />
                                             </VisualState.Setters>
                                             <!--<Storyboard>
                                                 <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
@@ -221,6 +234,14 @@
                             <Grid x:Name="RootGrid"
                                   Width="{Binding PaneWidth, ElementName=ThisPage}"
                                   Background="Transparent">
+                                
+                                <!-- See comment above under NavToggleButtonTemplate -->
+                                
+                                <Interactivity:Interaction.Behaviors>
+                                    <Core:DataTriggerBehavior Binding="{Binding IsSettingToNormalVisualState, ElementName=ThisPage}" Value="True">
+                                        <Core:GoToStateAction StateName="DummyState" />
+                                    </Core:DataTriggerBehavior>
+                                </Interactivity:Interaction.Behaviors>
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates" CurrentStateChanged="NavButton_VisualStateChanged">
                                         <VisualState x:Name="Normal">
@@ -256,6 +277,9 @@
                                                 <Setter Target="ContentPresenter.Background" Value="Transparent" />
                                             </VisualState.Setters>
                                         </VisualState>
+
+                                        <VisualState x:Name="DummyState" />
+
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
                                 <ContentPresenter x:Name="ContentPresenter" Content="{Binding Content}" />

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -551,6 +551,14 @@ namespace Template10.Controls
             {
                 button.HamburgerButtonInfo.RaiseUnchecked(e);
                 button.FrameworkElement.IsHitTestVisible = true;
+
+                // This fixes the VisualState transition with checking/unchecking a ToggleButton. Could this problem be 
+                // because there is no explicit "UnChecked" state for ToggleButton? Having spent sometime trying to figure
+                // out and nothing obvious, my only guess is that there must be a bug with the ToggleButton VisualState.
+                // This workaround forces the "UnChecked" state to the "Normal" visual state as it should.
+
+                ToggleButton btn = button.FrameworkElement as ToggleButton;
+                VisualStateManager.GoToState(btn, "Normal", false);
             }
         }
 


### PR DESCRIPTION
PR fixes ControlTemplate visual states to avoid visual anomalies when setting themes at runtime.

For background:
please see comments in PR #892 and #887. This is a PR confined to the HamburgerMenu control part.
To demo the fixes proposed here, the Sample project in #892 can be used.
If required I can post the PR for the Sample alone.
