### PR TITLE
Performance optimization for #902 issue

### DIFF
--- a/Template10 (Library)/Controls/PageHeader.cs
+++ b/Template10 (Library)/Controls/PageHeader.cs
@@ -114,5 +114,18 @@ namespace Template10.Controls
             {
                 (d as PageHeader).Content = e.NewValue;
             }));
+
+        private Button moreButton;
+
+        protected override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+            moreButton = GetTemplateChild("MoreButton") as Button;
+        }
+
+        internal Button GetMoreButton()
+        {
+            return moreButton;
+        }
     }
 }


### PR DESCRIPTION
Updated method of `MoreButton`  extraction from templated visual tree.

Replaced **very** expensive call `XamlUtils.AllChildren<Control>(commandBar)` with much optimized methods.

If `EllipsisBehavior` is applied to `PageHeader` control, used cached internal value (obtained and cached in overrided `OnApplyTemplate` protected method of `PageHeader` control). It is the most optimized method because WinRT call is performed only once when control template is applied.

If `EllipsisBehavior` is applied to `CommandBar`, used just 3 WinRT calls instead of very unoptimized manual visual tree walk.

Simple `FindName` works if called on templated visual tree root. No need for expensive manual tree walk with many WinRT interop calls.

```
if (VisualTreeHelper.GetChildrenCount(commandBar) > 0)  
{  
    var child = VisualTreeHelper.GetChild(commandBar, 0) as FrameworkElement; /* Templated root */  
    return child?.FindName("MoreButton") as Button;  
}  
```
