### PR TITLE
WindowWrapper.Default() get Main window

### DIFF
--- a/Samples/ShareTarget/App.xaml.cs
+++ b/Samples/ShareTarget/App.xaml.cs
@@ -30,7 +30,9 @@ namespace Template10.Samples.ShareTargetSample
             }
             else
             {
-                NavigationService.Navigate(typeof(Views.MainPage));
+                var nav = NavigationService ?? NavigationServiceFactory(BackButton.Attach, ExistingContent.Include);
+                Window.Current.Content = nav.Frame;
+                nav.Navigate(typeof(Views.MainPage));
             }
             return Task.CompletedTask;
         }

--- a/Template10 (Library)/Common/WindowWrapper.cs
+++ b/Template10 (Library)/Common/WindowWrapper.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Windows.ApplicationModel.Core;
 using Template10.Services.NavigationService;
 using Windows.Graphics.Display;
 using Windows.UI.ViewManagement;
@@ -29,7 +31,20 @@ namespace Template10.Common
             DebugWrite(caller: "Constructor");
         }
 
-        public static WindowWrapper Default() => ActiveWrappers.FirstOrDefault();
+        public static WindowWrapper Default()
+        {
+            try
+            {
+                var mainDispatcher = CoreApplication.MainView.Dispatcher;
+                return ActiveWrappers.FirstOrDefault(x => x.Window.Dispatcher == mainDispatcher) ??
+                        ActiveWrappers.FirstOrDefault();
+            }
+            catch (COMException)
+            {
+                //MainView might exist but still be not accessible
+                return ActiveWrappers.FirstOrDefault();
+            }
+        }
 
         public readonly static List<WindowWrapper> ActiveWrappers = new List<WindowWrapper>();
 


### PR DESCRIPTION
Changed WindowWrapper.Default() to try get Main window (via CoreApplication.MainView) first, before returning the first created.
This will allow to still get Main window In cases, when Activation (for example, ShareTarget, that happens in Hosted Window) is the first window created, and Main window is after.
But in this cases developers may need to check additionally for situations, that by default WindowWrapper.Default().NavigationService may be null as no default NavigationService and Frame will be created.
