### PR TITLE
Fix for successive calling of NavigationService.GoBack

### DIFF
--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -57,13 +57,15 @@ namespace Template10.Services.NavigationService
             FrameFacadeInternal.Navigated += async (s, e) =>
             {
                 var parameter = SerializationService.Deserialize(e.Parameter?.ToString());
+                var currentContent = FrameFacadeInternal.Frame.Content;
                 if (Equals(e.Parameter?.ToString(), SerializationService.Serialize(LastNavigationParameter)))
                     parameter = LastNavigationParameter;
                 await WindowWrapper.Current().Dispatcher.DispatchAsync(async () =>
                 {
                     try
                     {
-                        await NavigateToAsync(e.NavigationMode, parameter, FrameFacadeInternal.Frame.Content);
+                        if (currentContent == FrameFacadeInternal.Frame.Content)
+                            await NavigateToAsync(e.NavigationMode, parameter, FrameFacadeInternal.Frame.Content);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
In case of successive calling of **NavigationService.GoBack** due to asynchronously to **Frame.GoBack** call of **NavigatedToAsync** the last could be called (first and redundant) with a wrong parameter related to the previous navigated (after first GoBack) page.
