### PR TITLE
Issue 921 - Make sure page DataContext is set in resolver 

### DIFF
--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -82,6 +82,7 @@ namespace Template10.Services.NavigationService
                 var viewModel = BootStrapper.Current.ResolveForPage(page, this);
                 if ((viewModel != null))
                 {
+                    page.DataContext = viewModel;
                     return viewModel;
                 }
             }


### PR DESCRIPTION
#921 - If the page DataContext is not set, all nav events will cause a new view model to be instantiated if you are using the bootstrapper resolve override
