### PR TITLE
Jump List file opens on first launch

### DIFF
--- a/Samples/JumpList/ViewModels/MainPageViewModel.cs
+++ b/Samples/JumpList/ViewModels/MainPageViewModel.cs
@@ -26,7 +26,10 @@ namespace Template10.Samples.JumpListSample.ViewModels
 
         public override async Task OnNavigatedToAsync(object parameter, NavigationMode mode, IDictionary<string, object> state)
         {
-            File = await _DataService.GetFileInfoAsync(_SettingService.Recent);
+            if (string.IsNullOrWhiteSpace(parameter as string))
+                File = await _DataService.GetFileInfoAsync(_SettingService.Recent);
+            else
+                File = await _DataService.GetFileInfoAsync(parameter.ToString());
             App.FileReceived += FileReceivedHandler;
         }
 


### PR DESCRIPTION
Launching the application with a jump list item does not load that file but instead launches the most recent file. 
This is because the `FileReceived` event handler is not hooked up until after navigation to `MainPageViewModel`. After launch, running jump list items opens them correctly, the issue is only present on first launch.
`OnStartAsync` in `App.xaml` already passes the jump list item (if present) when navigating to `MainPageViewModel`.
