### PR TITLE
Fixes NullReferenceException that is thrown in Full Screen mode startup.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
@@ -64,7 +64,7 @@ namespace Template10.Controls
         }
         public static readonly DependencyProperty HamburgerForegroundProperty =
               DependencyProperty.Register(nameof(HamburgerForeground), typeof(Brush),
-                  typeof(HamburgerMenu), new PropertyMetadata(null, (d, e) => Changed(nameof(HamburgerForeground), e)));
+                  typeof(HamburgerMenu), new PropertyMetadata(Colors.White.ToSolidColorBrush(), (d, e) => Changed(nameof(HamburgerForeground), e)));
 
         public Brush HamburgerBackground
         {
@@ -73,7 +73,7 @@ namespace Template10.Controls
         }
         public static readonly DependencyProperty HamburgerBackgroundProperty =
             DependencyProperty.Register(nameof(HamburgerBackground), typeof(Brush),
-                typeof(HamburgerMenu), new PropertyMetadata(null, (d, e) => Changed(nameof(HamburgerBackground), e)));
+                typeof(HamburgerMenu), new PropertyMetadata(Colors.SteelBlue.ToSolidColorBrush(), (d, e) => Changed(nameof(HamburgerBackground), e)));
 
         // nav button | normal
 


### PR DESCRIPTION
In Full Screen mode, `FullScreenPropertyChanged` fires before HamburgerBackground brush is initialized, and fails with `System.NullReferenceException` at [L432 ](https://github.com/Windows-XAML/Template10/blob/master/Template10%20%28Library%29/Controls/HamburgerMenu.xaml.cs#L432)of HamburgerMenu.xaml.cs. This PR sets the null initial values to default brush values for the Dark Theme.

**Note** the non-null value is non persistent -- only to avoid NullReferenceException and doesn't matter what value;the usual theme setting follows for persisting brush values.

Perhaps a good idea to set all the brushes to their default non-null values? For now, it's only `FullScreenPropertyChanged` that needs fixing.
