### PR TITLE
Restores IsOpen toggle effect on a NavButton that is already checked.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -590,7 +590,7 @@ namespace Template10.Controls
         {
             DebugWrite($"OpenCloseMode {OpenCloseMode}");
 
-            if (IsOpen || DisplayMode == SplitViewDisplayMode.CompactInline || DisplayMode == SplitViewDisplayMode.Inline)
+            if (DisplayMode == SplitViewDisplayMode.CompactInline || DisplayMode == SplitViewDisplayMode.Inline)
             {
                 return;
             }


### PR DESCRIPTION
Restores IsOpen toggle effect on a NavButton that is already checked. Has undesired effect in the Overlay Display mode (e.g. Windows Phone).

I think we have been here before (a long time ago) and I don't know how this issue surfaced again.
Not something we can't live with but just a minor annoyance that shouldn't be there.
