### PR TITLE
Different keys used for PropertyChangedHandlers dictionary (DisplayMo…

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
@@ -191,7 +191,7 @@ namespace Template10.Controls
         }
         public static readonly DependencyProperty DisplayModeProperty =
             DependencyProperty.Register(nameof(DisplayMode), typeof(SplitViewDisplayMode),
-                typeof(HamburgerMenu), new PropertyMetadata(null, (d, e) => Changed(nameof(DisplayModeProperty), e)));
+                typeof(HamburgerMenu), new PropertyMetadata(null, (d, e) => Changed(nameof(DisplayMode), e)));
 
         /// <summary>
         /// This is one of three visual state properties. It sets the minimum value used to invoke the Wide visual state.


### PR DESCRIPTION
 Different keys used for PropertyChangedHandlers dictionary (DisplayMode and DisplayModeProperty).

Now I know why `private void DisplayModePropertyChanged(SplitViewDisplayMode previous, SplitViewDisplayMode value)` was never triggering! Phew!
