### PR TITLE
Adds DisplayModeChanged event to HamburgerMenu control.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.PublicMethods.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicMethods.xaml.cs
@@ -29,6 +29,7 @@ namespace Template10.Controls
         public event EventHandler PaneOpened;
         public event EventHandler PaneClosed;
         public event EventHandler<ChangedEventArgs<HamburgerButtonInfo>> SelectedChanged;
+        public event EventHandler<ChangedEventArgs<SplitViewDisplayMode>> DisplayModeChanged;
 
         public void RefreshStyles(ElementTheme theme, bool clearExisting = false)
         {

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -170,6 +170,7 @@ namespace Template10.Controls
                 ShellSplitView.DisplayMode = value;
             }
             HamburgerButtonGridWidth = (value == SplitViewDisplayMode.CompactInline) ? PaneWidth : squareWidth;
+            DisplayModeChanged?.Invoke(this, new ChangedEventArgs<SplitViewDisplayMode>(previous, value));
         }
 
         private void HamburgerButtonVisibilityPropertyChanged(Visibility value)


### PR DESCRIPTION
Okay, as a follow-up to PR #950, we can now add a `DisplayModeChanged` event to the HamburgerMenu control.
