### PR TITLE
Adds Loaded event to Literal Button's DataTemplate ContentPresenter.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -86,6 +86,7 @@
                                   MinWidth="48"
                                   MaxWidth="{x:Bind MaxWidth, Mode=TwoWay}"
                                   Content="{Binding Content}"
+                                  Loaded="NavButton_Loaded"
                                   ToolTipService.ToolTip="{Binding Path=(ToolTipService.ToolTip)}"
                                   Visibility="{Binding Visibility, Mode=TwoWay}" />
             </DataTemplate>


### PR DESCRIPTION
In response to Issue #959 flagged by @johanlindfors.
