### PR TITLE
Adjusts PageHeader's left Margin for Inline DisplayMode

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
@@ -268,11 +268,27 @@ namespace Template10.Controls
         public SplitViewDisplayMode DisplayMode
         {
             get { return (SplitViewDisplayMode)GetValue(DisplayModeProperty); }
-            set { SetValue(DisplayModeProperty, value); }
+            set
+            {
+                // Override DisplayMode for small screen sizes.
+                // Developer should set VisualStateNormalMinWidth value (default 521d) for HamburgerMenu,
+                // commonly in Shell.xaml or Shell.xaml.cs, for the value to propagate here in time for startup.
+                // It may be necessary to set DisplayMode as the last thing in Shell.Loaded event handler
+                // for values such as VisualStateNormalMinWidth to propagate from applying styles.
+
+                if (Window.Current.Bounds.Width < VisualStateNormalMinWidth)
+                {
+                    SetValue(DisplayModeProperty, SplitViewDisplayMode.Overlay);
+                }
+                else
+                {
+                    SetValue(DisplayModeProperty, value);
+                }
+            }
         }
         public static readonly DependencyProperty DisplayModeProperty =
             DependencyProperty.Register(nameof(DisplayMode), typeof(SplitViewDisplayMode),
-                typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.Inline, (d, e) =>
+                typeof(HamburgerMenu), new PropertyMetadata(null, (d, e) =>
                 {
                     Changed(nameof(DisplayMode), e);
                     (d as HamburgerMenu).DisplayModeChanged?.Invoke(d, e.ToChangedEventArgs<SplitViewDisplayMode>());
@@ -312,7 +328,7 @@ namespace Template10.Controls
         }
         public static readonly DependencyProperty VisualStateNormalMinWidthProperty =
             DependencyProperty.Register(nameof(VisualStateNormalMinWidth), typeof(double),
-                typeof(HamburgerMenu), new PropertyMetadata((double)0, (d, e) =>
+                typeof(HamburgerMenu), new PropertyMetadata((double)-1, (d, e) =>
                 {
                     Changed(nameof(VisualStateNormalMinWidth), e);
                     (d as HamburgerMenu).VisualStateNormalMinWidthChanged?.Invoke(d, e.ToChangedEventArgs<double>());

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -147,8 +147,8 @@ namespace Template10.Controls
 
         private void HamburgerMenu_DisplayModeChanged(object sender, ChangedEventArgs<SplitViewDisplayMode> e)
         {
-            HamburgerButtonGridWidth = (e.NewValue == SplitViewDisplayMode.CompactInline) ? PaneWidth : squareWidth;
             UpdateFullScreen();
+            UpdateHamburgerButtonGridWidth();
         }
 
         private void SplitView_IsPaneOpenChanged(DependencyObject sender, DependencyProperty dp)
@@ -160,7 +160,6 @@ namespace Template10.Controls
             }
 
             UpdateSecondaryButtonOrientation();
-            UpdateHamburgerButtonGridWidth();
             RaisePaneOpenedClosedEvents();
 
             // this will keep the two properties in sync
@@ -168,6 +167,8 @@ namespace Template10.Controls
             {
                 IsOpen = ShellSplitView.IsPaneOpen;
             }
+
+            UpdateHamburgerButtonGridWidth();
         }
 
         private void HamburgerMenu_HamburgerButtonVisibilityChanged(object sender, ChangedEventArgs<Visibility> e)
@@ -302,9 +303,9 @@ namespace Template10.Controls
 
         private void UpdateHamburgerButtonGridWidth()
         {
-            if (IsOpen)
+            if (DisplayMode == SplitViewDisplayMode.Inline || DisplayMode == SplitViewDisplayMode.CompactInline)
             {
-                HamburgerButtonGridWidth = (DisplayMode == SplitViewDisplayMode.CompactInline) ? ShellSplitView.OpenPaneLength : squareWidth;
+                HamburgerButtonGridWidth = (IsOpen) ? ShellSplitView.OpenPaneLength : squareWidth;
             }
             else
             {

--- a/Template10 (Library)/Template10 (Library).csproj
+++ b/Template10 (Library)/Template10 (Library).csproj
@@ -203,6 +203,7 @@
     <Compile Include="Utils\MonitorUtils.cs" />
     <Compile Include="Utils\IEnumerableUtils.cs" />
     <Compile Include="Utils\Template10Utils.cs" />
+    <Compile Include="Utils\VisualTree.cs" />
     <Compile Include="Utils\XamlUtils.cs" />
     <Compile Include="Controls\HamburgerMenu.xaml.cs">
       <DependentUpon>HamburgerMenu.xaml</DependentUpon>

--- a/Template10 (Library)/Utils/VisualTree.cs
+++ b/Template10 (Library)/Utils/VisualTree.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+using System.Linq;
+
+namespace Template10.Utils
+{
+    public static class VisualTree
+    {
+
+        /// <summary>
+        /// Gets the first ancestor that is of the given type.
+        /// </summary>
+        /// <remarks>
+        /// Returns null if not found.
+        /// </remarks>
+        /// <typeparam name="T">Type of ancestor to look for.</typeparam>
+        /// <param name="d">The DependencyObject where the Visual Tree starts.</param>
+        /// <returns></returns>
+        public static T GetFirstAncestorOfType<T>(this DependencyObject d) where T : DependencyObject
+        {
+            return d.GetAncestorsOfType<T>().FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets the the ancestors of a given type.
+        /// </summary>
+        /// <typeparam name="T">Type of ancestor to look for.</typeparam>
+        /// <param name="d">The DependencyObject where the Visual Tree starts.</param>
+        /// <returns></returns>
+        public static IEnumerable<T> GetAncestorsOfType<T>(this DependencyObject d) where T : DependencyObject
+        {
+            return d.GetAncestors().OfType<T>();
+        }
+
+        /// <summary>
+        /// Gets the ancestors.
+        /// </summary>
+        /// <param name="d">The DependencyObject where the Visual Tree starts.</param>
+        /// <returns></returns>
+        public static IEnumerable<DependencyObject> GetAncestors(this DependencyObject start)
+        {
+            var parent = VisualTreeHelper.GetParent(start);
+
+            while (parent != null)
+            {
+                yield return parent;
+                parent = VisualTreeHelper.GetParent(parent);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Re: #966 @JerryNixon 

Things go a bit haywire when DisplayMode is set to **Inline** on startup -- otherwise you may not notice this issue (but simply a problem hiding to show up later). The **Inline** DisplayMode presents a non-trivial problem -- unlike the Overlay display mode, when menu pane opens, it pushes the content (the Overlay, in contrast, simply casts the menu **over** the content), which means there is left-margin adjustment to be made for **PageHeader** when in Inline display mode. Sounds simple but there are many things at work here -- the display modes (4 of them!), the HB button container adjustment, together with PageHeader margin adjustment,  make the whole thing rather confusing.

There must be a simple XAML trick but didn't get that spark for a XAML trick so it's code-behind.  The code-behind can do the dirty job but until there's a consensus that there is no better alternative I won't be happy with this, but here we go ...

Problem: For some reason the ViewStates in the RelativePanel do not seem to trigger on startup - the reason why the startup is not as expected and extra code used to correct this (interestingly without the workaround the imperfection that shows up, such as page title positioning, etc, is self-correcting on page resize, display mode change etc, but ...).

Sufficiently commented with an indication of the VSM part that needs sorting out. It works.

**Note** It doesn't mean using Inline is imposed on the user in any way -- this is simply to accommodate starting up with Inline if the user wishes to, such a case flagged in #966.
