### PR TITLE
Add an option "ClearCache" to HamburgerButtonInfo

### DIFF
--- a/Template10 (Library)/Controls/HamburgerButtonInfo.cs
+++ b/Template10 (Library)/Controls/HamburgerButtonInfo.cs
@@ -106,6 +106,19 @@ namespace Template10.Controls
                 typeof(HamburgerButtonInfo), new PropertyMetadata(false));
 
         /// <summary>
+        /// Sets and gets the ClearCache property.
+        /// If true, navigation page cache is cleared when navigating to this page
+        /// </summary>
+        public bool ClearCache
+        {
+            get { return (bool)GetValue(ClearCacheProperty); }
+            set { SetValue(ClearCacheProperty, value); }
+        }
+        public static readonly DependencyProperty ClearCacheProperty =
+            DependencyProperty.Register(nameof(ClearCache), typeof(bool),
+                typeof(HamburgerButtonInfo), new PropertyMetadata(false));
+
+        /// <summary>
         /// Sets and gets the Visibility property.
         /// Changes to that property's value raise the PropertyChanged event. 
         /// </summary>

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -356,12 +356,16 @@ namespace Template10.Controls
                     IsOpen = (DisplayMode == SplitViewDisplayMode.CompactInline && IsOpen);
                     if (value.ClearHistory)
                         NavigationService.ClearHistory();
+                    if (value.ClearCache)
+                        NavigationService.ClearCache();
                 }
                 else if (NavigationService.CurrentPageType == value.PageType
                      && (NavigationService.CurrentPageParam ?? string.Empty) == (value.PageParameter ?? string.Empty))
                 {
                     if (value.ClearHistory)
                         NavigationService.ClearHistory();
+                    if (value.ClearCache)
+                        NavigationService.ClearCache();
                 }
                 else if (NavigationService.CurrentPageType == value.PageType)
                 {

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -357,7 +357,7 @@ namespace Template10.Controls
                     if (value.ClearHistory)
                         NavigationService.ClearHistory();
                     if (value.ClearCache)
-                        NavigationService.ClearCache();
+                        NavigationService.ClearCache(true);
                 }
                 else if (NavigationService.CurrentPageType == value.PageType
                      && (NavigationService.CurrentPageParam ?? string.Empty) == (value.PageParameter ?? string.Empty))
@@ -365,7 +365,7 @@ namespace Template10.Controls
                     if (value.ClearHistory)
                         NavigationService.ClearHistory();
                     if (value.ClearCache)
-                        NavigationService.ClearCache();
+                        NavigationService.ClearCache(true);
                 }
                 else if (NavigationService.CurrentPageType == value.PageType)
                 {


### PR DESCRIPTION
This pull request will add an option "ClearCache" to HamburgerButtonInfo. If set to true, navigation cache will be cleared when navigating to the page.
