### PR TITLE
Adds PreferredNormalDisplayMode and PreferredWideDisplayMode

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
@@ -295,6 +295,34 @@ namespace Template10.Controls
                 }));
         public event EventHandler<ChangedEventArgs<SplitViewDisplayMode>> DisplayModeChanged;
 
+
+        public SplitViewDisplayMode PreferredNormalDisplayMode
+        {
+            get { return (SplitViewDisplayMode)GetValue(PreferredNormalDisplayModeProperty); }
+            set { SetValue(PreferredNormalDisplayModeProperty, value); }
+        }
+
+        public static readonly DependencyProperty PreferredNormalDisplayModeProperty =
+            DependencyProperty.Register(nameof(PreferredNormalDisplayMode), typeof(SplitViewDisplayMode),
+                typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.CompactOverlay, (d, e) =>
+                {
+                    Changed(nameof(PreferredNormalDisplayMode), e);
+                }));
+
+        public SplitViewDisplayMode PreferredWideDisplayMode
+        {
+            get { return (SplitViewDisplayMode)GetValue(PreferredWideDisplayModeProperty); }
+            set { SetValue(PreferredWideDisplayModeProperty, value); }
+        }
+
+        public static readonly DependencyProperty PreferredWideDisplayModeProperty =
+            DependencyProperty.Register(nameof(PreferredWideDisplayMode), typeof(SplitViewDisplayMode),
+                typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.CompactInline, (d, e) =>
+                {
+                    Changed(nameof(PreferredWideDisplayMode), e);
+                }));
+
+
         /// <summary>
         /// This is one of three visual state properties. It sets the minimum value used to invoke the Wide visual state.
         /// </summary>

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -467,18 +467,18 @@ namespace Template10.Controls
             }
             else if (state == VisualStateNormal)
             {
-                if (DisplayMode != SplitViewDisplayMode.CompactOverlay)
+                if (DisplayMode != PreferredNormalDisplayMode)
                 {
-                    DisplayMode = SplitViewDisplayMode.CompactOverlay;
-                    IsOpen = false;
+                    DisplayMode = PreferredNormalDisplayMode;
+                    IsOpen = DisplayMode.ToString().Contains("Overlay") ? false : true;
                 }
             }
             else if (state == VisualStateWide)
             {
-                if (DisplayMode != SplitViewDisplayMode.CompactInline)
+                if (DisplayMode != PreferredWideDisplayMode)
                 {
-                    DisplayMode = SplitViewDisplayMode.CompactInline;
-                    IsOpen = true;
+                    DisplayMode = PreferredWideDisplayMode;
+                    IsOpen = DisplayMode.ToString().Contains("Overlay") ? false : true;
                 }
             }
         }


### PR DESCRIPTION
Adds **PreferredNormalDisplayMode** and **PreferredWideDisplayMode** dependency properties which will give FULL control to the developer as to how display modes are set.

Visual State control uses **PreferredNormalDisplayMode** and **PreferredWideDisplayMode**  instead of the _hard-wired_  **SplitViewDisplayMode.CompactOverlay** and **SplitViewDisplayMode.CompactInline**; 
If PreferredNormalDisplayMode and PreferredWideDisplayMode are not set, VSM works as before.
If, for instance, you want **CompactOverlay** for both _Normal_ and _Wide_ display modes you just set as:

```
<Controls:HamburgerMenu x:Name="MyHamburgerMenu"
                        PreferredNormalDisplayMode="CompactOverlay"
                        PreferredWideDisplayMode="CompactOverlay">
```

In fact, nothing stops you from setting any permutation of the 4 display modes, noting that the Overlay display mode will override for narrow width (because any other mode doesn't make much sense).

There is a very minor problem which @JerryNixon can provide an instant solution (based on what I have seen with the latest two merges which I find quite refreshing). If PreferredNormalDisplayMode or PreferredWideDisplayMode are set to **Overlay** or **Inline** the page title needs adjusting (the 48px PageHeader margin) when HM IsOpen is false. I haven't fully grasped the XAML dynamics as different components are involved and after a few attempts I gave up -- sorry Jerry!

Here is the thing: It doesn't mean something is wrong with this PR (as there is nothing complicated about it); it simply means that this PR provided more test cases -- for the Overlay and Inline -- because these display modes were not considered in the programming (for normal and wide display sizes). Resolving these issues will make T10 totally transparent and hence more robust as all possible (display mode) x (display size) combinations will  have been accounted for.
