### PR TITLE
Removes a circular call to UpdateVisualStates(); VisualState[Narrow|N…

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
@@ -288,6 +288,7 @@ namespace Template10.Controls
             DependencyProperty.Register(nameof(VisualStateNarrowDisplayMode), typeof(SplitViewDisplayMode),
                 typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.Overlay, (d, e) =>
                 {
+                    (d as HamburgerMenu).UpdateVisualStates();
                     Changed(nameof(VisualStateNarrowDisplayMode), e);
                     (d as HamburgerMenu).VisualStateNarrowDisplayModeChanged?.Invoke(d, e.ToChangedEventArgs<SplitViewDisplayMode>());
                 }));
@@ -302,6 +303,7 @@ namespace Template10.Controls
             DependencyProperty.Register(nameof(VisualStateNormalDisplayMode), typeof(SplitViewDisplayMode),
                 typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.CompactOverlay, (d, e) =>
                 {
+                    (d as HamburgerMenu).UpdateVisualStates();
                     Changed(nameof(VisualStateNormalDisplayMode), e);
                     (d as HamburgerMenu).VisualStateNormalDisplayModeChanged?.Invoke(d, e.ToChangedEventArgs<SplitViewDisplayMode>());
                 }));
@@ -316,6 +318,7 @@ namespace Template10.Controls
             DependencyProperty.Register(nameof(VisualStateWideDisplayMode), typeof(SplitViewDisplayMode),
                 typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.CompactInline, (d, e) =>
                 {
+                    (d as HamburgerMenu).UpdateVisualStates();
                     Changed(nameof(VisualStateWideDisplayMode), e);
                     (d as HamburgerMenu).VisualStateWideDisplayModeChanged?.Invoke(d, e.ToChangedEventArgs<SplitViewDisplayMode>());
                 }));

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -413,10 +413,6 @@ namespace Template10.Controls
         {
             DebugWrite($"Manual: {manualFullScreen}, IsFullScreen: {IsFullScreen} DisplayMode: {DisplayMode}");
 
-            if (!IsFullScreen)
-            {
-                UpdateVisualStates();
-            }
 
             UpdateFullScreen(manualFullScreen);
         }
@@ -469,7 +465,7 @@ namespace Template10.Controls
             {
                 DisplayMode = VisualStateWideDisplayMode;
             }
-            IsOpen = DisplayMode.ToString().Contains("Overlay") ? false : true;
+            IsOpen = (DisplayMode == SplitViewDisplayMode.CompactInline) ? true : false;
         }
 
         #endregion

--- a/Template10 (Library)/Utils/XamlUtils.cs
+++ b/Template10 (Library)/Utils/XamlUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -103,6 +104,37 @@ namespace Template10.Utils
                 case ApplicationTheme.Dark:
                 default:
                     return ElementTheme.Dark;
+            }
+        }
+
+        public static T FirstDescendant<T>(this DependencyObject control) where T : DependencyObject
+        {
+            return control.Descendants().OfType<T>().FirstOrDefault();
+        }
+
+        public static IEnumerable<DependencyObject> Descendants(this DependencyObject control)
+        {
+            var queue = new Queue<DependencyObject>();
+            var count = VisualTreeHelper.GetChildrenCount(control);
+
+            for (int i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(control, i);
+                yield return child;
+                queue.Enqueue(child);
+            }
+
+            while (queue.Count > 0)
+            {
+                var parent = queue.Dequeue();
+                var count2 = VisualTreeHelper.GetChildrenCount(parent);
+
+                for (int i = 0; i < count2; i++)
+                {
+                    var child = VisualTreeHelper.GetChild(parent, i);
+                    yield return child;
+                    queue.Enqueue(child);
+                }
             }
         }
 


### PR DESCRIPTION
StackOverflow!
I don't mean _The Website_ but there's a circular call to `UpdateVisualStates()` causing stackoverflow.

UpdateVisualStates() -> HamburgerMenu_DisplayModeChanged() -> UpdateControl() -> ~~if (!IsFullScreen) UpdateVisualStates()~~

Also, **VisualState[Narrow|Normal|Wide]DisplayMode** now invoke UpdateVisualStates() upon change as they should.
