### PR TITLE
Avoid new navigation to the current page in some race conditions

### DIFF
--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -222,11 +222,14 @@ namespace Template10.Services.NavigationService
             if (page == null)
                 throw new ArgumentNullException(nameof(page));
 
-            if ((page.FullName == LastNavigationType) && (parameter == LastNavigationParameter))
+            // use CurrentPageType/Param instead of LastNavigationType/Parameter to avoid new navigation to the current
+            // page in some race conditions.
+            if ((page.FullName == CurrentPageType?.FullName) && (parameter == CurrentPageParam))
                 return false;
 
-            if ((page.FullName == LastNavigationType) && (parameter?.Equals(LastNavigationParameter) ?? false))
+            if ((page.FullName == CurrentPageType?.FullName) && (parameter?.Equals(CurrentPageParam) ?? false))
                 return false;
+
 
             parameter = SerializationService.Serialize(parameter);
 


### PR DESCRIPTION
In some cases new navigation to the current page could happen.
For example if:
- On startup we navigate to Page1.
- NavigationService.CurrentPageType becomes Page1.
- NavigationService.NavigateToAsync (which updates LastNavigationType/Parameter) is called on another thread.
- Before NavigateToAsync updates LastNavigationType/Parameter, HamburgerMenu calls (after loading all nav buttons) HighlightCorrectButton, which uses CurrentPageType/Parameter to set selected button, that calls NavigationService.NavigateAsync.
- If at that time LastNavigationPage/Parameter are not updated yet, then NavigationService.NavigateAsync will call FrameFacadeInternal.Navigate to Page1.
  
  I've faced it (in more than 30%) in an app that uses protocol activation.
