### PR TITLE
VisualState[Narrow|Normal|Wide]DisplayMode invoke UpdateVisualStates(…

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
@@ -334,6 +334,7 @@ namespace Template10.Controls
             DependencyProperty.Register(nameof(VisualStateNarrowDisplayMode), typeof(SplitViewDisplayMode),
                 typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.Overlay, (d, e) =>
                 {
+                    (d as HamburgerMenu).UpdateVisualStates();
                     WriteDebug(nameof(VisualStateNarrowDisplayMode), e);
                     (d as HamburgerMenu).VisualStateNarrowDisplayModeChanged?.Invoke(d, e.ToChangedEventArgs<SplitViewDisplayMode>());
                     (d as HamburgerMenu).InternalVisualStateNarrowDisplayModeChanged(e.ToChangedEventArgs<SplitViewDisplayMode>());
@@ -351,6 +352,7 @@ namespace Template10.Controls
             DependencyProperty.Register(nameof(VisualStateNormalDisplayMode), typeof(SplitViewDisplayMode),
                 typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.CompactOverlay, (d, e) =>
                 {
+                    (d as HamburgerMenu).UpdateVisualStates();
                     WriteDebug(nameof(VisualStateNormalDisplayMode), e);
                     (d as HamburgerMenu).VisualStateNormalDisplayModeChanged?.Invoke(d, e.ToChangedEventArgs<SplitViewDisplayMode>());
                     (d as HamburgerMenu).InternalVisualStateNormalDisplayModeChanged(e.ToChangedEventArgs<SplitViewDisplayMode>());
@@ -368,6 +370,7 @@ namespace Template10.Controls
             DependencyProperty.Register(nameof(VisualStateWideDisplayMode), typeof(SplitViewDisplayMode),
                 typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.CompactInline, (d, e) =>
                 {
+                    (d as HamburgerMenu).UpdateVisualStates();
                     WriteDebug(nameof(VisualStateWideDisplayMode), e);
                     (d as HamburgerMenu).VisualStateWideDisplayModeChanged?.Invoke(d, e.ToChangedEventArgs<SplitViewDisplayMode>());
                     (d as HamburgerMenu).InternalVisualStateWideDisplayModeChanged(e.ToChangedEventArgs<SplitViewDisplayMode>());

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -628,12 +628,11 @@ namespace Template10.Controls
             }
             switch (mode)
             {
-                case SplitViewDisplayMode.Overlay:
-                case SplitViewDisplayMode.CompactOverlay:
-                    IsOpen = false;
+                case SplitViewDisplayMode.CompactInline:
+                    IsOpen = true;
                     break;
                 default:
-                    IsOpen = true;
+                    IsOpen = false;
                     break;
             }
         }


### PR DESCRIPTION
~~Removes a circular call to UpdateVisualStates();~~ VisualState[Narrow|Normal|Wide]DisplayMode invoke UpdateVisualStates() on change.

Did PR again due to merge conflict being flagged. It appears that the _circular call_ problem is done manually since??
