### PR TITLE
When CurrentPageType is serialized, use AssemblyQualifiedName

### DIFF
--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -311,7 +311,7 @@ namespace Template10.Services.NavigationService
                 throw new InvalidOperationException("State container is unexpectedly null");
             }
 
-            state.Write<string>("CurrentPageType", CurrentPageType.ToString());
+            state.Write<string>("CurrentPageType", CurrentPageType.AssemblyQualifiedName);
             state.Write<object>("CurrentPageParam", CurrentPageParam);
             state.Write<string>("NavigateState", FrameFacadeInternal?.GetNavigationState());
             await Task.CompletedTask;


### PR DESCRIPTION
When CurrentPageType is serialized, use AssemblyQualifiedName for type name because "ToString()" cannot be resolved in Type.GetType() when resuming.
