### PR TITLE
Adjusts PageHeader title margin in Inline DisplayMode.

### DIFF
--- a/Template10 (Library)/Controls/PageHeader.cs
+++ b/Template10 (Library)/Controls/PageHeader.cs
@@ -68,13 +68,13 @@ namespace Template10.Controls
                 {
                     switch (hamburgerMenu.DisplayMode)
                     {
+                        case SplitViewDisplayMode.Inline:
                         case SplitViewDisplayMode.Overlay:
                             {
                                 var buttonVisible = hamburgerMenu.HamburgerButtonVisibility == Visibility.Visible;
                                 spacer.Visibility = buttonVisible ? Visibility.Visible : Visibility.Collapsed;
                             }
                             break;
-                        case SplitViewDisplayMode.Inline:
                         case SplitViewDisplayMode.CompactOverlay:
                         case SplitViewDisplayMode.CompactInline:
                             {


### PR DESCRIPTION
### Problem

In **Inline** DisplayMode, PageHeader title left-margin will be short by 48px.
### Test Scenario

Start up with **Inline** DisplayMode, example in _HamburgerMenu project_ as

```
<c:HamburgerMenu x:Name="MyHamburgerMenu"
    VisualStateNormalDisplayMode="Inline"
    VisualStateWideDisplayMode="Inline">
```
### Solution

This PR adjusts PageHeader title left-margin in **Inline** DisplayMode and fixes the above problem.
### Remark

Hope this puts **HamburgerMenu**'s **DisplayMode** [perfection](https://i.kinja-img.com/gawker-media/image/upload/s--BdEb-Dl5--/c_scale,fl_progressive,q_80,w_800/185xbqdcr7fgmjpg.jpg) to rest.
