### PR TITLE
Makes app resume after task switch.

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -213,11 +213,11 @@ namespace Template10.Common
                     {
                         OnResuming(this, null, AppExecutionState.Terminated);
 
-						/*
+                        /*
                             Restore state if you need to/can do.
                             Remember that only the primary tile or when user has
-							switched to the app (for instance via the task switcher)
-							should restore. (this includes toast with no data payload)
+                            switched to the app (for instance via the task switcher)
+                            should restore. (this includes toast with no data payload)
                             The rest are already providing a nav path.
 
                             In the event that the cache has expired, attempting to restore
@@ -226,16 +226,16 @@ namespace Template10.Common
                         */
 
 						
-						if (EnableAutoRestoreAfterTerminated)
-						{
-							var launchedEvent = e as ILaunchActivatedEventArgs;
+                        if (EnableAutoRestoreAfterTerminated)
+                        {
+                            var launchedEvent = e as ILaunchActivatedEventArgs;
 
-							if(DetermineStartCause(e) == AdditionalKinds.Primary || launchedEvent?.TileId == "")
-							{
-								restored = await NavigationService.RestoreSavedNavigationAsync();
-								DebugWrite($"{nameof(restored)}:{restored}", caller: nameof(NavigationService.RestoreSavedNavigationAsync));
-							}
-						}
+                            if(DetermineStartCause(e) == AdditionalKinds.Primary || launchedEvent?.TileId == "")
+                            {
+                                restored = await NavigationService.RestoreSavedNavigationAsync();
+                                DebugWrite($"{nameof(restored)}:{restored}", caller: nameof(NavigationService.RestoreSavedNavigationAsync));
+                            }
+                        }
                         break;
                     }
                 case ApplicationExecutionState.ClosedByUser:
@@ -749,7 +749,6 @@ namespace Template10.Common
                 return AdditionalKinds.Toast;
             }
             var e = args as ILaunchActivatedEventArgs;
-			
             if (e?.TileId == DefaultTileID && string.IsNullOrEmpty(e?.Arguments))
             {
                 return AdditionalKinds.Primary;


### PR DESCRIPTION
Currently Template10 only resumes app if it was activated when it was activated from primary tile. However, it should also resume if it gets activated via task switch. This is detected by checking if TileId is an empty string. Reference:

https://msdn.microsoft.com/en-us/library/windows/apps/hh700588(v=win.10).aspx?appid=dev14idef1&l=en-us&k=k(windows.applicationmodel.activation.ilaunchactivatedeventargs.tileid)%3bk(solutionitemsproject)%3bk(targetframeworkmoniker-.netcore,version%3dv5.0)%3bk(devlang-csharp)&rd=true

I detected this when running my app on Windows Phone, and these changes seems to solve the issue. I haven’t been able to replicated this on a computer. And I have no idea how to test this in Visual Studio :-/.
