### PR TITLE
Add RateApp command and widget 

### DIFF
--- a/Templates (Project)/Hamburger/ViewModels/SettingsPageViewModel.cs
+++ b/Templates (Project)/Hamburger/ViewModels/SettingsPageViewModel.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Template10.Mvvm;
 using Template10.Services.SettingsService;
 using Windows.UI.Xaml;
+using Windows.System;
 
 namespace Sample.ViewModels
 {
@@ -104,5 +105,11 @@ namespace Sample.ViewModels
         }
 
         public Uri RateMe => new Uri("http://aka.ms/template10");
+
+        DelegateCommand _RateAppCommand;
+        public DelegateCommand RateAppCommand
+            => _RateAppCommand ?? (_RateAppCommand = new DelegateCommand(async () =>
+                await Launcher.LaunchUriAsync(new Uri($"ms-windows-store:REVIEW?PFN={Windows.ApplicationModel.Package.Current.Id.FamilyName}")),
+                () => !string.IsNullOrEmpty(Windows.ApplicationModel.Package.Current.Id.FamilyName)));
     }
 }

--- a/Templates (Project)/Hamburger/Views/SettingsPage.xaml
+++ b/Templates (Project)/Hamburger/Views/SettingsPage.xaml
@@ -204,6 +204,21 @@
                         <Run Text="{Binding Version}" />
                     </TextBlock>
 
+                    <StackPanel
+                        x:Name="RateOurAppPanel" 
+                        Orientation="Horizontal" 
+                        RelativePanel.Below="VersionTextBlock">
+                        <TextBlock 
+                            Text="&#xE8E1;" 
+                            FontFamily="Segoe MDL2 Assets" 
+                            VerticalAlignment="Center"/>
+                        <HyperlinkButton 
+                            Margin="6,0,0,0" 
+                            Command="{Binding RateAppCommand}" 
+                            Content="Rate our app" 
+                            VerticalAlignment="Center"/>
+                    </StackPanel>
+
                 </RelativePanel>
             </PivotItem>
         </Pivot>


### PR DESCRIPTION
Added a command to the `SettingsPageViewModel`that will open the app in the windows app store, and a little thumbs up "Rate our app" widget on the about tab of the `SettingsPage`.
