### PR TITLE
Text amended for accuracy.

### DIFF
--- a/Samples/DynamicThemes/Views/MainPage.xaml
+++ b/Samples/DynamicThemes/Views/MainPage.xaml
@@ -85,7 +85,7 @@
             <Run Text="Current theme setting will be saved and restored on next app session. " />
             <LineBreak />
             <LineBreak />
-            <Run Text="The 'Checked Button Indicator Line' (CBIL ?) also works as well with dynamic update. It's currently set to Transparent but you can change it in Custom.xaml. " />
+            <Run Text="The 'Checked Button Indicator Line' (CBIL ?) also updates dynamically as the rest of the menu components. In fact, you can choose CBIL as an option under settings menu. Try it!" />
         </TextBlock>
 
 


### PR DESCRIPTION
@JerryNixon -- I added the 'Checked Button Indicator Line' at the last minute and now noticed that the explanatory notes on the landing page didn't reflect this. Now it does.
