### PR TITLE
Corrects a method name for KeyBehavior CallMethodAction in Search Sample Project.

### DIFF
--- a/Samples/Search/Controls/SearchPart.xaml
+++ b/Samples/Search/Controls/SearchPart.xaml
@@ -52,7 +52,7 @@
                     <TextBox Width="216">
                         <Interactivity:Interaction.Behaviors>
                             <Behaviors:TextBoxEnterKeyBehavior>
-                                <Core:CallMethodAction MethodName="Template10.Samples.SearchSample" TargetObject="{Binding ElementName=userControl}" />
+                                <Core:CallMethodAction MethodName="Search" TargetObject="{Binding ElementName=userControl}" />
                             </Behaviors:TextBoxEnterKeyBehavior>
                         </Interactivity:Interaction.Behaviors>
                     </TextBox>


### PR DESCRIPTION
You'll notice this little bug only if you press the **Enter** key,  but overlooked for so long because we're more inclined to tap on the search **Button** for same action. The **CallMethodAction** was not provided with the correct method name hence an Exception [here](https://github.com/Windows-XAML/Template10/blob/master/Template10%20%28Library%29/Behaviors/TextBoxEnterKeyBehavior.cs#L34).

This PR reminded me that **TextBoxEnterKeyBehavior** needs to be updated with **KeyBehavior** so more PR's coming up.
