### PR TITLE
Fixes Double numeric value parsing from a currency string.

### DIFF
--- a/Samples/BottomAppBar/Converters/NumberColorConverter.cs
+++ b/Samples/BottomAppBar/Converters/NumberColorConverter.cs
@@ -2,6 +2,7 @@
 using Template10.Utils;
 using Windows.UI;
 using Windows.UI.Xaml.Data;
+using System.Text.RegularExpressions;
 
 namespace Template10.Samples.BottomAppBarSample.Converters
 {
@@ -9,7 +10,10 @@ namespace Template10.Samples.BottomAppBarSample.Converters
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            var d = value.ToString().Replace("$", string.Empty).Replace("%", string.Empty).Replace(" ", string.Empty).Replace("(", "-").Replace(")", string.Empty);
+            // Pattern to strip off currency symbol by retaining negative sign and decimal point.
+            Regex regex = new Regex(@"[^\d-.]+");
+
+            var d = regex.Replace(value.ToString(), string.Empty);
             return double.Parse(d) > 0 ? Colors.Green.ToSolidColorBrush() : Colors.Red.ToSolidColorBrush();
         }
 


### PR DESCRIPTION
Fixes Double numeric value parsing from a currency string -- used in the Sample to show negative and positive values in Red and Green, respectively.

The **NumberColorConverter** was failing where a regional setting uses a different currency symbol (other than the dollar $ sign). Hope the **RegEx** pattern I used will account for all eventualities ;-). 

The regex pattern doesn't care about currency symbols -- it strips off any non-numeric with the exception of negative sign and decimal point that should leave behind a double number. Is there a gotcha here?
