### PR TITLE
Fixes "The name 'PropertyChanged_ViewModel' does not exist in the current context"

### DIFF
--- a/Templates (Project)/Hamburger/Views/DetailPage.xaml
+++ b/Templates (Project)/Hamburger/Views/DetailPage.xaml
@@ -60,7 +60,7 @@
                       VerticalScrollBarVisibility="Auto">
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="You passed:" />
-                <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{x:Bind ViewModel.Value, Mode=OneWay, FallbackValue=DesigntimeValue}" />
+                <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{x:Bind ViewModel.Value, FallbackValue=DesigntimeValue}" />
             </StackPanel>
         </ScrollViewer>
 

--- a/Templates (Project)/Minimal/Views/DetailPage.xaml
+++ b/Templates (Project)/Minimal/Views/DetailPage.xaml
@@ -60,7 +60,7 @@
                       VerticalScrollBarVisibility="Auto">
             <StackPanel>
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="You passed:" />
-                <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{x:Bind ViewModel.Value, Mode=OneWay, FallbackValue=DesigntimeValue}" />
+                <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{x:Bind ViewModel.Value, FallbackValue=DesigntimeValue}" />
             </StackPanel>
         </ScrollViewer>
 


### PR DESCRIPTION
A fix for the error "The name 'PropertyChanged_ViewModel' does not exist in the current context" that appears while compiling a newly created UWP project with Minimal or Hamburger templates. 

Going by the [docs here](https://msdn.microsoft.com/en-us/library/system.windows.data.binding.mode%28v=vs.110%29.aspx), The BindingMode of TextBlock element defaults to OneWay and so there is no need to specify it explicitly. 
