### PR TITLE
Corrects the method name for KeyBehavior CallMethodAction in Search sample project.

### DIFF
--- a/Samples/Search/Controls/SearchPart.xaml
+++ b/Samples/Search/Controls/SearchPart.xaml
@@ -52,7 +52,7 @@
                     <TextBox Width="216">
                         <Interactivity:Interaction.Behaviors>
                             <Behaviors:KeyBehavior Key="Enter">
-                                <Core:CallMethodAction MethodName="Template10.Samples.SearchSample" TargetObject="{Binding ElementName=userControl}" />
+                                <Core:CallMethodAction MethodName="Search" TargetObject="{Binding ElementName=userControl}" />
                             </Behaviors:KeyBehavior>
                         </Interactivity:Interaction.Behaviors>
                     </TextBox>


### PR DESCRIPTION
Corrects the method name for KeyBehavior CallMethodAction in Search sample project.

You'll notice this little bug only if you press the Enter key, but overlooked for so long because we're more inclined to tap on the search Button for same action. The CallMethodAction was not provided with the correct method name hence an Exception [here](https://github.com/Windows-XAML/Template10/blob/master/Template10%20%28Library%29/Behaviors/TextBoxEnterKeyBehavior.cs#L34).

@JerryNixon - This resolves the Branch Conflict for PR #1039.
