### PR TITLE
Ensures that SecondaryButtonOrientation is set on starting up in CompactInline DisplayMode.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -640,7 +640,13 @@ namespace Template10.Controls
         #endregion
 
         private StackPanel _SecondaryButtonStackPanel;
-        private void SecondaryButtonStackPanel_Loaded(object sender, RoutedEventArgs e) => _SecondaryButtonStackPanel = sender as StackPanel;
+        private void SecondaryButtonStackPanel_Loaded(object sender, RoutedEventArgs e)
+        {
+            _SecondaryButtonStackPanel = sender as StackPanel;
+
+            UpdateSecondaryButtonOrientation();
+
+        }
 
         #region Nav Buttons
 


### PR DESCRIPTION
### Problem:

If an app starts in **CompactInline** DisplayMode, it fails to update `SecondaryButtonOrientation` because the **SecondaryButtonContainer** StackPanel is not yet loaded and it [gracefully] misses out on first chance `UpdateSecondaryButtonOrientation()` method within `SplitView_IsPaneOpenChanged` event handler.
### Solution:

Easy. Just put the missed out `UpdateSecondaryButtonOrientation()` method call in the **SecondaryButtonContainer** StackPanel `Loaded` event handler to catch up and all will be fine. Note that the problem would be self-correcting for other display modes, because menu pane opening provides the needed trigger for [a second-time chance] `UpdateSecondaryButtonOrientation()` method call (the closed pane with other modes just concealed away the problem that CompactInline revealed -- interesting how bugs hide themselves).
### Gotchas!
- It's your responsibility to collapse menu items under `HamburgerMenu.SecondaryButtons` to `MaxWidth=48` so that the icons line up horizontally, else some of them disappear sideways since the label strings also take up space. (This can be done easily by binding the `MaxWidth` of all secondary menu items to a single Property).
- Furthermore, make sure that the secondary icons can fit into the `HamburgerMenu.PaneWidth` which means the max number of icons `= Int(HamburgerMenu.PaneWidth/48)`.
- It's also your responsibility to provide a spacer so that the most-right (or most-left for rtl system) icon aligns nicely with the margin; this is for aesthetics but not something to be ignored lightly. The **Dynamic Themes** sample project shows how the spacing and alignment is done.
