### PR TITLE
Add several ConfigureAwait(false) calls to awaits

### DIFF
--- a/Template10 (Library)/Common/EventThrottleHelper.cs
+++ b/Template10 (Library)/Common/EventThrottleHelper.cs
@@ -70,7 +70,7 @@ namespace Template10.Common
             }
             try
             {
-                await DelayAction(eventData);
+                await DelayAction(eventData).ConfigureAwait(false);
             }
             catch
             {
@@ -88,7 +88,7 @@ namespace Template10.Common
             {
                 try
                 {
-                    await DelayAction(eventData);
+                    await DelayAction(eventData).ConfigureAwait(false);
                 }
                 catch
                 {
@@ -126,7 +126,7 @@ namespace Template10.Common
                     var toWait = (stamp.AddMilliseconds(Throttle) - DateTime.Now);
                     if (toWait.Ticks > 0)
                     {
-                        await Task.Delay(toWait);
+                        await Task.Delay(toWait).ConfigureAwait(false);
                     }
                 }
             }

--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -294,7 +294,7 @@ namespace Template10.Services.NavigationService
                 args.NavigationMode = NavigationModeHint;
             NavigationModeHint = NavigationMode.New;
             _navigatingEventHandlers.ForEach(x => x(this, args));
-            await deferral.WaitForDeferralsAsync();
+            await deferral.WaitForDeferralsAsync().ConfigureAwait(false);
             e.Cancel = args.Cancel;
         }
     }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -327,7 +327,7 @@ namespace Template10.Services.NavigationService
                 await NavigateToAsync(NavigationMode.Refresh, FrameFacadeInternal.CurrentPageParam);
                 while (FrameFacadeInternal.Frame.Content == null)
                 {
-                    Task.Yield().GetAwaiter().GetResult();
+                    await Task.Delay(1);
                 }
                 AfterRestoreSavedNavigation?.Invoke(this, FrameFacadeInternal.CurrentPageType);
                 return true;

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -70,7 +70,7 @@ namespace Template10.Services.NavigationService
                         e.Cancel = !(await NavigatingFromAsync(page, dataContext, false, e.NavigationMode));
                         if (!e.Cancel)
                         {
-                            await NavigateFromAsync(page, dataContext, false);
+                            await NavigateFromAsync(page, dataContext, false).ConfigureAwait(false);
                         }
                     }
                 }
@@ -86,14 +86,14 @@ namespace Template10.Services.NavigationService
                     try
                     {
                         if (currentContent == FrameFacadeInternal.Frame.Content)
-                            await NavigateToAsync(e.NavigationMode, parameter, FrameFacadeInternal.Frame.Content);
+                            await NavigateToAsync(e.NavigationMode, parameter, FrameFacadeInternal.Frame.Content).ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
                         DebugWrite($"DispatchAsync/NavigateToAsync {ex.Message}");
                         throw;
                     }
-                }, 1);
+                }, 1).ConfigureAwait(false);
             };
         }
 
@@ -130,7 +130,7 @@ namespace Template10.Services.NavigationService
                 Suspending = suspending,
             };
             await deferral.WaitForDeferralsAsync();
-            await dataContext.OnNavigatingFromAsync(args);
+            await dataContext.OnNavigatingFromAsync(args).ConfigureAwait(false);
             return !args.Cancel;
         }
 
@@ -144,7 +144,7 @@ namespace Template10.Services.NavigationService
             dataContext.SessionState = BootStrapper.Current.SessionState;
 
             var pageState = FrameFacadeInternal.PageStateSettingsService(page.GetType()).Values;
-            await dataContext.OnNavigatedFromAsync(pageState, suspending);
+            await dataContext.OnNavigatedFromAsync(pageState, suspending).ConfigureAwait(false);
         }
 
         async Task NavigateToAsync(NavigationMode mode, object parameter, object frameContent = null)
@@ -204,7 +204,7 @@ namespace Template10.Services.NavigationService
 
                 await ApplicationViewSwitcher
                     .TryShowAsStandaloneAsync(newAppView.Id, ViewSizePreference.Default, currentView.Id, size);
-            });
+            }).ConfigureAwait(false);
         }
 
         public async Task<bool> NavigateAsync(Type page, object parameter = null, NavigationTransitionInfo infoOverride = null)
@@ -233,7 +233,7 @@ namespace Template10.Services.NavigationService
         {
             DebugWrite($"Page: {page}, Parameter: {parameter}, NavigationTransitionInfo: {infoOverride}");
 
-            await NavigateAsync(page, parameter, infoOverride);
+            await NavigateAsync(page, parameter, infoOverride).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -270,7 +270,7 @@ namespace Template10.Services.NavigationService
 
             var page = keys[key];
 
-            return await NavigateAsync(page, parameter, infoOverride);
+            return await NavigateAsync(page, parameter, infoOverride).ConfigureAwait(false);
         }
 
         public async void Navigate<T>(T key, object parameter = null, NavigationTransitionInfo infoOverride = null)
@@ -278,7 +278,7 @@ namespace Template10.Services.NavigationService
         {
             DebugWrite($"Key: {key}, Parameter: {parameter}, NavigationTransitionInfo: {infoOverride}");
 
-            await NavigateAsync(key, parameter, infoOverride);
+            await NavigateAsync(key, parameter, infoOverride).ConfigureAwait(false);
         }
 
         public ISerializationService SerializationService { get; set; }
@@ -383,7 +383,7 @@ namespace Template10.Services.NavigationService
                 var dataContext = ResolveForPage(page);
                 if (dataContext != null)
                 {
-                    await NavigateFromAsync(page, dataContext, true);
+                    await NavigateFromAsync(page, dataContext, true).ConfigureAwait(false);
                 }
             }
         }

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -225,7 +225,6 @@ namespace Template10.Services.NavigationService
 
             parameter = SerializationService.Serialize(parameter);
 
-            await Task.CompletedTask;
             return FrameFacadeInternal.Navigate(page, parameter, infoOverride);
         }
 
@@ -304,7 +303,6 @@ namespace Template10.Services.NavigationService
             state.Write<string>("CurrentPageType", CurrentPageType.AssemblyQualifiedName);
             state.Write<object>("CurrentPageParam", CurrentPageParam);
             state.Write<string>("NavigateState", FrameFacadeInternal?.NavigationService.NavigationState);
-            await Task.CompletedTask;
         }
 
         public event TypedEventHandler<Type> AfterRestoreSavedNavigation;


### PR DESCRIPTION
This PR will add several ConfigureAwait(false) calls to awaits. This is useful when we are sure that we do not need to return on the UI thread after await. Also removed two unneccessary await Task.CompletedTask; calls.
