### PR TITLE
Fixed crash NavigationService.OpenAsync

### DIFF
--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -193,7 +193,7 @@ namespace Template10.Services.NavigationService
             var dispatcher = new DispatcherWrapper(newView.Dispatcher);
             await dispatcher.DispatchAsync(async () =>
             {
-                var newWindow = this.GetWindowWrapper().Window;
+                var newWindow = WindowWrapper.Current().Window;
                 var newAppView = ApplicationView.GetForCurrentView();
                 newAppView.Title = title;
 


### PR DESCRIPTION
Due to incorrect Window through NavigationService a crash with wrong thread marshalling appeared. Fixed changing to get CurrentWindow, as it was initially.
