### PR TITLE
Synchronous Navigate methods should wait until navigation finishes

### DIFF
--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -228,11 +228,11 @@ namespace Template10.Services.NavigationService
             return FrameFacadeInternal.Navigate(page, parameter, infoOverride);
         }
 
-        public async void Navigate(Type page, object parameter = null, NavigationTransitionInfo infoOverride = null)
+        public void Navigate(Type page, object parameter = null, NavigationTransitionInfo infoOverride = null)
         {
             DebugWrite($"Page: {page}, Parameter: {parameter}, NavigationTransitionInfo: {infoOverride}");
 
-            await NavigateAsync(page, parameter, infoOverride).ConfigureAwait(false);
+            NavigateAsync(page, parameter, infoOverride).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -272,12 +272,12 @@ namespace Template10.Services.NavigationService
             return await NavigateAsync(page, parameter, infoOverride).ConfigureAwait(false);
         }
 
-        public async void Navigate<T>(T key, object parameter = null, NavigationTransitionInfo infoOverride = null)
+        public void Navigate<T>(T key, object parameter = null, NavigationTransitionInfo infoOverride = null)
             where T : struct, IConvertible
         {
             DebugWrite($"Key: {key}, Parameter: {parameter}, NavigationTransitionInfo: {infoOverride}");
 
-            await NavigateAsync(key, parameter, infoOverride).ConfigureAwait(false);
+            NavigateAsync(key, parameter, infoOverride).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public ISerializationService SerializationService { get; set; }


### PR DESCRIPTION
Synchronous Navigate methods should wait until navigation finishes. So with PR removes async keyword from syncronous Navigate methods and lets them wait using GetAwaiter().GetResult() call. The ConfigureAwait(false) makes sure that this does not block the UI thread.
