### PR TITLE
NavToPageAction doesn't work.

### DIFF
--- a/Template10 (Library)/Behaviors/NavToPageAction.cs
+++ b/Template10 (Library)/Behaviors/NavToPageAction.cs
@@ -26,15 +26,7 @@ namespace Template10.Behaviors
             if (nav == null)
                 throw new NullReferenceException($"Cannot find NavigationService for {Frame.ToString()}.");
 
-            var metadataProvider = Application.Current as IXamlMetadataProvider;
-            if (metadataProvider == null)
-                return false;
-
-            var pagetype = metadataProvider.GetXamlType(Page as Type);
-            if (pagetype == null)
-                throw new NullReferenceException($"Cannot find TargetPage:{Page}");
-
-            nav.Navigate(pagetype as Type, Parameter, InfoOverride);
+            nav.Navigate(Page as Type, Parameter, InfoOverride);
             return null;
         }
 


### PR DESCRIPTION
Hi.

Navigate expects a page type to navigate on a page. The Page dependency property which is an object must be bound in xaml to a page type (System.Type).

The pagetype variable (returned from metadataProvider.GetXamlType(Page as Type); ) when cast to  Type is null...

Just giving the Page to the navigation is enough.
