### PR TITLE
Removing exception-based logic and unintended reference capture in closure

### DIFF
--- a/Template10 (Library)/Behaviors/NavButtonBehavior.cs
+++ b/Template10 (Library)/Behaviors/NavButtonBehavior.cs
@@ -44,7 +44,7 @@ namespace Template10.Behaviors
                 // handle click
                 element.Click += new Common.WeakReference<NavButtonBehavior, object, RoutedEventArgs>(this)
                 {
-                    EventAction = (i, s, e) => Element_Click(s, e),
+                    EventAction = (i, s, e) => i.Element_Click(s, e),
                     DetachAction = (i, w) => element.Click -= w.Handler,
                 }.Handler;
                 CalculateThrottled();

--- a/Template10 (Library)/Common/WeakReference.cs
+++ b/Template10 (Library)/Common/WeakReference.cs
@@ -4,42 +4,46 @@ namespace Template10.Common
 {
     public class WeakReference<TInstance, TSource, TEventArgs> where TInstance : class
     {
-        public WeakReference Reference { get; protected set; }
+        public WeakReference<TInstance> Reference { get; protected set; }
         public Action<TInstance, TSource, TEventArgs> EventAction { get; set; }
         public Action<TInstance, WeakReference<TInstance, TSource, TEventArgs>> DetachAction { get; set; }
-        public WeakReference(TInstance instance) { Reference = new WeakReference(instance); }
+        public WeakReference(TInstance instance) { Reference = new WeakReference<TInstance>(instance); }
 
         public virtual void Handler(TSource source, TEventArgs eventArgs)
         {
-            try
+            TInstance instance;
+            if (Reference != null && Reference.TryGetTarget(out instance))
             {
-                EventAction(Reference?.Target as TInstance, source, eventArgs);
+                EventAction?.Invoke(instance, source, eventArgs);
             }
-            catch
+            else
             {
-                DetachAction?.Invoke(Reference?.Target as TInstance, this);
-                DetachAction = null;
+                // Instance surely doesn't survive garbage collections, so passing null for it
+                // Don't removed unnecessary delegate parameter for backward compatibility
+                DetachAction?.Invoke(null, this);
             }
         }
     }
 
     public class WeakReference<TInstance, TSource> where TInstance : class
     {
-        public WeakReference Reference { get; protected set; }
+        public WeakReference<TInstance> Reference { get; protected set; }
         public Action<TInstance, TSource> EventAction { get; set; }
         public Action<TInstance, WeakReference<TInstance, TSource>> DetachAction { get; set; }
-        public WeakReference(TInstance instance) { Reference = new WeakReference(instance); }
+        public WeakReference(TInstance instance) { Reference = new WeakReference<TInstance>(instance); }
 
         public virtual void Handler(TSource source)
         {
-            try
+            TInstance instance;
+            if (Reference != null && Reference.TryGetTarget(out instance))
             {
-                EventAction(Reference?.Target as TInstance, source);
+                EventAction?.Invoke(instance, source);
             }
-            catch
+            else
             {
-                DetachAction?.Invoke(Reference?.Target as TInstance, this);
-                DetachAction = null;
+                // Instance surely doesn't survive garbage collections, so passing null for it
+                // Don't removed unnecessary delegate parameter for backward compatibility
+                DetachAction?.Invoke(null, this);
             }
         }
     }


### PR DESCRIPTION
Fixed unintended reference capture in closure

Here was error
`EventAction = (i, s, e) => Element_Click(s, e),`
changed to
`EventAction = (i, s, e) => i.Element_Click(s, e),`

Without "i" qualifier `this` reference was captured rendering WeakReference useless.

In WeakReference.cs changed logic from exception-based to more straightforward.
Overall exception-based logic was erroneous.
If any exception is raised within event handler code, such handler will be detached.
Also, simple check if refrence is still alive (using `TryGetTarget`) is much more efficient and clear than to catch generic exception.

Also, performed check if `EventAction` is null, because `EventAction` property isn't read-only.
