### PR TITLE
Fix for  #1082 issue (removed LayoutUpdated handlers)

### DIFF
--- a/Template10 (Library)/Behaviors/DeviceDispositionBehavior.cs
+++ b/Template10 (Library)/Behaviors/DeviceDispositionBehavior.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
+using Template10.Utils;
 
 namespace Template10.Behaviors
 {
@@ -14,14 +15,21 @@ namespace Template10.Behaviors
     {
         public DependencyObject AssociatedObject { get; set; }
 
+        private DeviceUtils _deviceUtils;
+
         public void Attach(DependencyObject associatedObject)
         {
             AssociatedObject = associatedObject;
-            Utils.DeviceUtils.Current().Changed += DeviceDispositionBehavior_Changed;
+            _deviceUtils = Utils.DeviceUtils.Current();
+            if (_deviceUtils != null) _deviceUtils.Changed += DeviceDispositionBehavior_Changed;
             Update();
         }
 
-        public void Detach() => Utils.DeviceUtils.Current().Changed -= DeviceDispositionBehavior_Changed;
+        public void Detach()
+        {
+            if (_deviceUtils != null) _deviceUtils.Changed -= DeviceDispositionBehavior_Changed;
+        }
+        
         private void DeviceDispositionBehavior_Changed(object sender, EventArgs e) => Update();
         private void Run() => Interaction.ExecuteActions(AssociatedObject, Actions, null);
 

--- a/Template10 (Library)/Behaviors/EllipsisBehavior.cs
+++ b/Template10 (Library)/Behaviors/EllipsisBehavior.cs
@@ -15,13 +15,13 @@ namespace Template10.Behaviors
     public class EllipsisBehavior : DependencyObject, IBehavior
     {
         private CommandBar commandBar => AssociatedObject as CommandBar;
+
         public DependencyObject AssociatedObject { get; private set; }
 
         public void Attach(DependencyObject associatedObject)
         {
             AssociatedObject = associatedObject;
             commandBar.Loaded += CommandBar_Loaded;
-            commandBar.LayoutUpdated += CommandBar_LayoutUpdated;
             commandBar.PrimaryCommands.VectorChanged += Commands_VectorChanged;
             commandBar.SecondaryCommands.VectorChanged += Commands_VectorChanged;
             Update();
@@ -30,13 +30,12 @@ namespace Template10.Behaviors
         public void Detach()
         {
             commandBar.Loaded -= CommandBar_Loaded;
-            commandBar.LayoutUpdated -= CommandBar_LayoutUpdated;
             commandBar.PrimaryCommands.VectorChanged -= Commands_VectorChanged;
             commandBar.SecondaryCommands.VectorChanged -= Commands_VectorChanged;
         }
 
         private void CommandBar_Loaded(object sender, RoutedEventArgs e) => Update();
-        private void CommandBar_LayoutUpdated(object sender, object e) => Update();
+
         private void Commands_VectorChanged(IObservableVector<ICommandBarElement> sender, IVectorChangedEventArgs @event) => Update();
 
         public enum Visibilities { Visible, Collapsed, Auto }

--- a/Template10 (Library)/Behaviors/NavButtonBehavior.cs
+++ b/Template10 (Library)/Behaviors/NavButtonBehavior.cs
@@ -18,12 +18,19 @@ namespace Template10.Behaviors
     public class NavButtonBehavior : DependencyObject, IBehavior
     {
         private IDispatcherWrapper _dispatcher;
-        private EventThrottleHelper _throttleHelper;
+        private readonly EventThrottleHelper _throttleHelper;
         private DeviceUtils _deviceUtils;
 
         Button element => AssociatedObject as Button;
 
         public DependencyObject AssociatedObject { get; set; }
+
+        public NavButtonBehavior()
+        {
+            _throttleHelper = new EventThrottleHelper();
+            _throttleHelper.ThrottledEvent += delegate { Calculate(); };
+            _throttleHelper.Throttle = 1000;
+        }
 
         public void Attach(DependencyObject associatedObject)
         {
@@ -37,11 +44,6 @@ namespace Template10.Behaviors
             else
             {
                 _dispatcher = Common.DispatcherWrapper.Current();
-
-                // throttled calculate event
-                _throttleHelper = new EventThrottleHelper();
-                _throttleHelper.ThrottledEvent += delegate { Calculate(); };
-                _throttleHelper.Throttle = 1000;
 
                 // handle click
                 element.Click += new Common.WeakReference<NavButtonBehavior, object, RoutedEventArgs>(this)
@@ -63,7 +65,6 @@ namespace Template10.Behaviors
 
         public void Detach()
         {
-            _throttleHelper = null;
             DetachFrameEvents(this, Frame);
             if (BootStrapper.Current != null) BootStrapper.Current.ShellBackButtonUpdated -= Current_ShellBackButtonUpdated;
             if (_deviceUtils != null) _deviceUtils.Changed -= DispositionChanged;

--- a/Template10 (Library)/Behaviors/NavButtonBehavior.cs
+++ b/Template10 (Library)/Behaviors/NavButtonBehavior.cs
@@ -155,6 +155,7 @@ namespace Template10.Behaviors
         private static void FrameChanged(DependencyObject d, DependencyPropertyChangedEventArgs args)
         {
             var behavior = (NavButtonBehavior)d;
+            DetachFrameEvents(behavior, args.OldValue as Frame);
             AttachFrameEvents(behavior, args.NewValue as Frame);
             behavior.CalculateThrottled();
         }

--- a/Template10 (Library)/Behaviors/NavButtonBehavior.cs
+++ b/Template10 (Library)/Behaviors/NavButtonBehavior.cs
@@ -73,6 +73,8 @@ namespace Template10.Behaviors
 
         private void OnNavigated(object sender, NavigationEventArgs navigationEventArgs) => CalculateThrottled();
 
+        private void FrameOnLoaded(object sender, RoutedEventArgs routedEventArgs) => CalculateThrottled();
+
         private void CalculateThrottled()
         {
             _throttleHelper?.DispatchTriggerEvent(null);
@@ -179,6 +181,7 @@ namespace Template10.Behaviors
             eventReg.GoBackReg = frame.RegisterPropertyChangedCallback(Frame.CanGoBackProperty, (s, e) => behavior.CalculateThrottled());
             eventReg.GoForwardReg = frame.RegisterPropertyChangedCallback(Frame.CanGoForwardProperty, (s, e) => behavior.CalculateThrottled());
             frame.Navigated += behavior.OnNavigated;
+            frame.Loaded += behavior.FrameOnLoaded;
         }
 
         private static void DetachFrameEvents(NavButtonBehavior behavior, Frame frame)
@@ -197,6 +200,7 @@ namespace Template10.Behaviors
             frame.UnregisterPropertyChangedCallback(Frame.CanGoBackProperty, eventReg.GoBackReg);
             frame.UnregisterPropertyChangedCallback(Frame.CanGoForwardProperty, eventReg.GoForwardReg);
             frame.Navigated -= behavior.OnNavigated;
+            frame.Loaded -= behavior.FrameOnLoaded;
         }
 
         private class FrameEventRegistration

--- a/Template10 (Library)/Behaviors/NavButtonBehavior.cs
+++ b/Template10 (Library)/Behaviors/NavButtonBehavior.cs
@@ -196,18 +196,21 @@ namespace Template10.Behaviors
             // continuum mode
             var touchmode = UIViewSettings.GetForCurrentView().UserInteractionMode == UserInteractionMode.Touch;
 
+            // store value locally to avoid multiple WinRT interop calls
+            var deviceFamily = Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily;
+
             // mobile always has a visible back button
-            var mobilefam = "Windows.Mobile".Equals(Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily, StringComparison.OrdinalIgnoreCase);
+            var mobilefam = "Windows.Mobile".Equals(deviceFamily, StringComparison.OrdinalIgnoreCase);
             if (mobilefam && touchmode)
                 // this means phone, not continuum, which uses hardware (or steering wheel) back button
                 return Visibility.Collapsed;
 
             // handle iot
-            var iotfam = "Windows.IoT".Equals(Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily, StringComparison.OrdinalIgnoreCase);
+            var iotfam = "Windows.IoT".Equals(deviceFamily, StringComparison.OrdinalIgnoreCase);
             if (!iotfam)
             {
                 // simply don't know what to do with else
-                var desktopfam = "Windows.Desktop".Equals(Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily, StringComparison.OrdinalIgnoreCase);
+                var desktopfam = "Windows.Desktop".Equals(deviceFamily, StringComparison.OrdinalIgnoreCase);
                 if (!desktopfam)
                     return Visibility.Collapsed;
             }

--- a/Template10 (Library)/Behaviors/NavButtonBehavior.cs
+++ b/Template10 (Library)/Behaviors/NavButtonBehavior.cs
@@ -28,14 +28,18 @@ namespace Template10.Behaviors
         public NavButtonBehavior()
         {
             _dispatcher = Common.DispatcherWrapper.Current();
-            _throttleHelper = new EventThrottleHelper();
-            _throttleHelper.ThrottledEvent += delegate { Calculate(); };
-            _throttleHelper.Throttle = 1000;
+            _throttleHelper = new EventThrottleHelper { Throttle = 1000 };
+        }
+
+        private void ThrottleHelperOnThrottledEvent(object sender, object o)
+        {
+            Calculate();
         }
 
         public void Attach(DependencyObject associatedObject)
         {
             AssociatedObject = associatedObject;
+            _throttleHelper.ThrottledEvent += ThrottleHelperOnThrottledEvent;
 
             // process start
             if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
@@ -64,6 +68,7 @@ namespace Template10.Behaviors
 
         public void Detach()
         {
+            _throttleHelper.ThrottledEvent -= ThrottleHelperOnThrottledEvent;
             DetachFrameEvents(this, Frame);
             if (BootStrapper.Current != null) BootStrapper.Current.ShellBackButtonUpdated -= Current_ShellBackButtonUpdated;
             if (_deviceUtils != null) _deviceUtils.Changed -= DispositionChanged;

--- a/Template10 (Library)/Behaviors/NavButtonBehavior.cs
+++ b/Template10 (Library)/Behaviors/NavButtonBehavior.cs
@@ -7,6 +7,8 @@ using Windows.UI.Xaml.Controls;
 using Microsoft.Xaml.Interactivity;
 using Template10.Utils;
 using System;
+using System.Runtime.CompilerServices;
+using Windows.UI.Xaml.Navigation;
 using Template10.Common;
 
 namespace Template10.Behaviors
@@ -15,12 +17,12 @@ namespace Template10.Behaviors
     [Microsoft.Xaml.Interactivity.TypeConstraint(typeof(Button))]
     public class NavButtonBehavior : DependencyObject, IBehavior
     {
-        private long _goBackReg;
-        private long _goForwardReg;
         private IDispatcherWrapper _dispatcher;
         private EventThrottleHelper _throttleHelper;
+        private DeviceUtils _deviceUtils;
 
         Button element => AssociatedObject as Button;
+
         public DependencyObject AssociatedObject { get; set; }
 
         public void Attach(DependencyObject associatedObject)
@@ -48,35 +50,28 @@ namespace Template10.Behaviors
                     DetachAction = (i, w) => element.Click -= w.Handler,
                 }.Handler;
                 CalculateThrottled();
-                BootStrapper.Current.ShellBackButtonUpdated += Current_ShellBackButtonUpdated;
+                if (BootStrapper.Current != null) BootStrapper.Current.ShellBackButtonUpdated += Current_ShellBackButtonUpdated;
+                _deviceUtils = DeviceUtils.Current();
+                if (_deviceUtils != null) _deviceUtils.Changed += DispositionChanged;
             }
         }
 
-        private void Current_ShellBackButtonUpdated(object sender, EventArgs e) => Calculate();
+        private void DispositionChanged(object sender, EventArgs eventArgs)
+        {
+            CalculateThrottled();
+        }
 
         public void Detach()
         {
             _throttleHelper = null;
-            if (Frame != null)
-            {
-                Frame.SizeChanged -= SizeChanged;
-                Frame.LayoutUpdated -= LayoutUpdated;
-            }
-            UnregisterPropertyChangedCallback(Frame.CanGoBackProperty, _goBackReg);
-            UnregisterPropertyChangedCallback(Frame.CanGoForwardProperty, _goForwardReg);
-            BootStrapper.Current.ShellBackButtonUpdated += Current_ShellBackButtonUpdated;
+            DetachFrameEvents(this, Frame);
+            if (BootStrapper.Current != null) BootStrapper.Current.ShellBackButtonUpdated -= Current_ShellBackButtonUpdated;
+            if (_deviceUtils != null) _deviceUtils.Changed -= DispositionChanged;
         }
 
-        volatile bool _letLayoutUpdatedInvoke = false;
-        private void SizeChanged(object sender, SizeChangedEventArgs e) { _letLayoutUpdatedInvoke = true; }
-        private void LayoutUpdated(object sender, object e)
-        {
-            if (_letLayoutUpdatedInvoke)
-            {
-                _letLayoutUpdatedInvoke = false;
-                CalculateThrottled();
-            }
-        }
+        private void Current_ShellBackButtonUpdated(object sender, EventArgs e) => Calculate();
+
+        private void OnNavigated(object sender, NavigationEventArgs navigationEventArgs) => CalculateThrottled();
 
         private void CalculateThrottled()
         {
@@ -133,12 +128,12 @@ namespace Template10.Behaviors
                 {
                     case Directions.Back:
                         {
-                            element.Visibility = CalculateBackVisibility(Frame);
+                            element.Visibility = NavButtonsHelper.CalculateBackVisibility(Frame);
                             break;
                         }
                     case Directions.Forward:
                         {
-                            element.Visibility = CalculateForwardVisibility(Frame);
+                            element.Visibility = NavButtonsHelper.CalculateForwardVisibility(Frame);
                             break;
                         }
                 }
@@ -146,96 +141,67 @@ namespace Template10.Behaviors
         }
 
         public enum Directions { Back, Forward }
+
         public Directions Direction { get { return (Directions)GetValue(DirectionProperty); } set { SetValue(DirectionProperty, value); } }
+
         public static readonly DependencyProperty DirectionProperty = DependencyProperty.Register(nameof(Direction),
             typeof(Directions), typeof(NavButtonBehavior), new PropertyMetadata(Directions.Back));
 
         public Frame Frame { get { return (Frame)GetValue(FrameProperty); } set { SetValue(FrameProperty, value); } }
+
         public static readonly DependencyProperty FrameProperty = DependencyProperty.Register(nameof(Frame),
             typeof(Frame), typeof(NavButtonBehavior), new PropertyMetadata(null, FrameChanged));
+
         private static void FrameChanged(DependencyObject d, DependencyPropertyChangedEventArgs args)
         {
-            var behavior = (d as NavButtonBehavior);
-            var frame = args.NewValue as Frame;
-            if (frame != null)
-            {
-                behavior._goBackReg = frame.RegisterPropertyChangedCallback(Frame.CanGoBackProperty, (s, e) => behavior.CalculateThrottled());
-                behavior._goForwardReg = frame.RegisterPropertyChangedCallback(Frame.CanGoForwardProperty, (s, e) => behavior.CalculateThrottled());
-                frame.SizeChanged += behavior.SizeChanged;
-                frame.LayoutUpdated += behavior.LayoutUpdated;
-            }
+            var behavior = (NavButtonBehavior)d;
+            AttachFrameEvents(behavior, args.NewValue as Frame);
             behavior.CalculateThrottled();
         }
 
-        public static Visibility CalculateForwardVisibility(Frame frame)
+        private readonly ConditionalWeakTable<Frame, FrameEventRegistration> _eventRegistrationInfo = new ConditionalWeakTable<Frame, FrameEventRegistration>();
+
+        private static void AttachFrameEvents(NavButtonBehavior behavior, Frame frame)
         {
-            // in some cases frame may be null, esp. race conditions
-            if (frame == null)
-                return Visibility.Collapsed;
-
-            // by design it is not visible when not applicable
-            var cangoforward = frame.CanGoForward;
-            if (!cangoforward)
-                return Visibility.Collapsed;
-
-            // at this point, we show the on-canvas button
-            return Visibility.Visible;
+            if (behavior == null || frame == null)
+            {
+                return;
+            }
+            FrameEventRegistration eventReg;
+            if (behavior._eventRegistrationInfo.TryGetValue(frame, out eventReg))
+            {
+                // events already attached
+                return;
+            }
+            eventReg = new FrameEventRegistration();
+            behavior._eventRegistrationInfo.Add(frame, eventReg);
+            eventReg.GoBackReg = frame.RegisterPropertyChangedCallback(Frame.CanGoBackProperty, (s, e) => behavior.CalculateThrottled());
+            eventReg.GoForwardReg = frame.RegisterPropertyChangedCallback(Frame.CanGoForwardProperty, (s, e) => behavior.CalculateThrottled());
+            frame.Navigated += behavior.OnNavigated;
         }
 
-        public static Visibility CalculateBackVisibility(Frame frame)
+        private static void DetachFrameEvents(NavButtonBehavior behavior, Frame frame)
         {
-            // in some cases frame may be null, esp. race conditions
-            if (frame == null)
-                return Visibility.Collapsed;
-
-            // by design it is not visible when not applicable
-            var cangoback = frame.CanGoBack;
-            if (!cangoback)
-                return Visibility.Collapsed;
-
-            // continuum mode
-            var touchmode = UIViewSettings.GetForCurrentView().UserInteractionMode == UserInteractionMode.Touch;
-
-            // store value locally to avoid multiple WinRT interop calls
-            var deviceFamily = Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily;
-
-            // mobile always has a visible back button
-            var mobilefam = "Windows.Mobile".Equals(deviceFamily, StringComparison.OrdinalIgnoreCase);
-            if (mobilefam && touchmode)
-                // this means phone, not continuum, which uses hardware (or steering wheel) back button
-                return Visibility.Collapsed;
-
-            // handle iot
-            var iotfam = "Windows.IoT".Equals(deviceFamily, StringComparison.OrdinalIgnoreCase);
-            if (!iotfam)
+            if (behavior == null || frame == null)
             {
-                // simply don't know what to do with else
-                var desktopfam = "Windows.Desktop".Equals(deviceFamily, StringComparison.OrdinalIgnoreCase);
-                if (!desktopfam)
-                    return Visibility.Collapsed;
+                return;
             }
-
-            // touch always has a visible back button (continuum)
-            if (!iotfam && touchmode)
-                return Visibility.Collapsed;
-
-            // full screen back button is only visible when mouse reveals title (prefered behavior is on-canvas visible)
-            var fullscreen = ApplicationView.GetForCurrentView().IsFullScreenMode; // don't confuse with IsFullScreen
-            if (fullscreen)
-                return Visibility.Visible;
-
-            // hide the button if the shell button is visible
-            var optinback = SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility.Equals(AppViewBackButtonVisibility.Visible);
-            if (optinback)
+            FrameEventRegistration eventReg;
+            if (!behavior._eventRegistrationInfo.TryGetValue(frame, out eventReg))
             {
-                // shell button will not be visible if there is no title bar
-                var hastitle = !CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar;
-                if (hastitle)
-                    return Visibility.Collapsed;
+                // events already detached
+                return;
             }
+            behavior._eventRegistrationInfo.Remove(frame);
+            frame.UnregisterPropertyChangedCallback(Frame.CanGoBackProperty, eventReg.GoBackReg);
+            frame.UnregisterPropertyChangedCallback(Frame.CanGoForwardProperty, eventReg.GoForwardReg);
+            frame.Navigated -= behavior.OnNavigated;
+        }
 
-            // at this point, we show the on-canvas button
-            return Visibility.Visible;
+        private class FrameEventRegistration
+        {
+            public long GoBackReg;
+            public long GoForwardReg;
         }
     }
 }

--- a/Template10 (Library)/Behaviors/NavButtonBehavior.cs
+++ b/Template10 (Library)/Behaviors/NavButtonBehavior.cs
@@ -17,7 +17,7 @@ namespace Template10.Behaviors
     [Microsoft.Xaml.Interactivity.TypeConstraint(typeof(Button))]
     public class NavButtonBehavior : DependencyObject, IBehavior
     {
-        private IDispatcherWrapper _dispatcher;
+        private readonly IDispatcherWrapper _dispatcher;
         private readonly EventThrottleHelper _throttleHelper;
         private DeviceUtils _deviceUtils;
 
@@ -27,6 +27,7 @@ namespace Template10.Behaviors
 
         public NavButtonBehavior()
         {
+            _dispatcher = Common.DispatcherWrapper.Current();
             _throttleHelper = new EventThrottleHelper();
             _throttleHelper.ThrottledEvent += delegate { Calculate(); };
             _throttleHelper.Throttle = 1000;
@@ -43,8 +44,6 @@ namespace Template10.Behaviors
             }
             else
             {
-                _dispatcher = Common.DispatcherWrapper.Current();
-
                 // handle click
                 element.Click += new Common.WeakReference<NavButtonBehavior, object, RoutedEventArgs>(this)
                 {
@@ -125,7 +124,7 @@ namespace Template10.Behaviors
                 return;
 
             // make changes on UI thread
-            _dispatcher.Dispatch(() =>
+            _dispatcher?.Dispatch(() =>
             {
                 switch (Direction)
                 {

--- a/Template10 (Library)/Common/NavButtonsHelper.cs
+++ b/Template10 (Library)/Common/NavButtonsHelper.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Windows.ApplicationModel.Core;
+using Windows.UI.Core;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Template10.Common
+{
+    /// <summary>
+    /// Helper class for navigation buttons visibility logic.
+    /// </summary>
+    /// <remarks>Moved logic here from NavButtonBehavior because public static methods should be in a static class.</remarks>
+    public static class NavButtonsHelper
+    {
+        /// <summary>
+        /// Calculate forward navigation button visibility for a frame.
+        /// </summary>
+        /// <param name="frame">Frame.</param>
+        /// <returns>Button visibility.</returns>
+        public static Visibility CalculateForwardVisibility(Frame frame)
+        {
+            // in some cases frame may be null, esp. race conditions
+            if (frame == null)
+                return Visibility.Collapsed;
+
+            // by design it is not visible when not applicable
+            var cangoforward = frame.CanGoForward;
+            if (!cangoforward)
+                return Visibility.Collapsed;
+
+            // at this point, we show the on-canvas button
+            return Visibility.Visible;
+        }
+
+        /// <summary>
+        /// Calculate forward navigation button visibility for a frame.
+        /// </summary>
+        /// <param name="frame">Frame.</param>
+        /// <returns>Button visibility.</returns>
+        public static Visibility CalculateBackVisibility(Frame frame)
+        {
+            // in some cases frame may be null, esp. race conditions
+            if (frame == null)
+                return Visibility.Collapsed;
+
+            // by design it is not visible when not applicable
+            var cangoback = frame.CanGoBack;
+            if (!cangoback)
+                return Visibility.Collapsed;
+
+            // continuum mode
+            var touchmode = UIViewSettings.GetForCurrentView().UserInteractionMode == UserInteractionMode.Touch;
+
+            // store value locally to avoid multiple WinRT interop calls
+            var deviceFamily = Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily;
+
+            // mobile always has a visible back button
+            var mobilefam = "Windows.Mobile".Equals(deviceFamily, StringComparison.OrdinalIgnoreCase);
+            if (mobilefam && touchmode)
+                // this means phone, not continuum, which uses hardware (or steering wheel) back button
+                return Visibility.Collapsed;
+
+            // handle iot
+            var iotfam = "Windows.IoT".Equals(deviceFamily, StringComparison.OrdinalIgnoreCase);
+            if (!iotfam)
+            {
+                // simply don't know what to do with else
+                var desktopfam = "Windows.Desktop".Equals(deviceFamily, StringComparison.OrdinalIgnoreCase);
+                if (!desktopfam)
+                    return Visibility.Collapsed;
+            }
+
+            // touch always has a visible back button (continuum)
+            if (!iotfam && touchmode)
+                return Visibility.Collapsed;
+
+            // full screen back button is only visible when mouse reveals title (prefered behavior is on-canvas visible)
+            var fullscreen = ApplicationView.GetForCurrentView().IsFullScreenMode; // don't confuse with IsFullScreen
+            if (fullscreen)
+                return Visibility.Visible;
+
+            // hide the button if the shell button is visible
+            var optinback = SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility.Equals(AppViewBackButtonVisibility.Visible);
+            if (optinback)
+            {
+                // shell button will not be visible if there is no title bar
+                var hastitle = !CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar;
+                if (hastitle)
+                    return Visibility.Collapsed;
+            }
+
+            // at this point, we show the on-canvas button
+            return Visibility.Visible;
+        }
+    }
+}

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -55,7 +55,6 @@ namespace Template10.Controls
 
                 // control event handlers
                 Loaded += HamburgerMenu_Loaded;
-                LayoutUpdated += HamburgerMenu_LayoutUpdated;
 
                 // xbox controller menu button support
                 KeyboardService.Instance.AfterMenuGesture += () =>
@@ -97,6 +96,11 @@ namespace Template10.Controls
             UpdateHamburgerButtonGridWidthToFillAnyGap();
             RefreshStyles(RequestedTheme);
             UpdatePaneMarginToShowHamburgerButton();
+
+            // Moved here from HamburgerMenu_LayoutUpdated because it was one-time event handler.
+            // LayoutUpdated handler is not needed, Loaded is called after template applying anyway.
+            UpdateVisualStates();
+            UpdateControl();
         }
 
         private void HamburgerMenu_RequestedThemeChanged(DependencyObject sender, DependencyProperty dp)
@@ -104,15 +108,6 @@ namespace Template10.Controls
             DebugWrite();
 
             RefreshStyles(RequestedTheme);
-        }
-
-        private void HamburgerMenu_LayoutUpdated(object sender, object e)
-        {
-            DebugWrite();
-
-            LayoutUpdated -= HamburgerMenu_LayoutUpdated;
-            UpdateVisualStates();
-            UpdateControl();
         }
 
         // handle keyboard navigation (tabs and gamepad)

--- a/Template10 (Library)/Template10 (Library).csproj
+++ b/Template10 (Library)/Template10 (Library).csproj
@@ -152,6 +152,7 @@
     <Compile Include="Common\IStateItems.cs" />
     <Compile Include="Common\ItemPropertyChangedEventArgs.cs" />
     <Compile Include="Common\Mdl2.cs" />
+    <Compile Include="Common\NavButtonsHelper.cs" />
     <Compile Include="Common\ObservableDictionary.cs" />
     <Compile Include="Common\StateItems.cs" />
     <Compile Include="Common\StateKey.cs" />


### PR DESCRIPTION
Proposed fix for #1082 issue

@JerryNixon Please, review these changes carefully

I have made changes as I understand its logic, because no one helped me with information. If I'm wrong, please, point me on it.
## For all three classes which handle this event
### EllipsisBehavior

Simply removed `LayoutUpdated` event handler  because `Loaded` event handling is enough. `Loaded` event on WinRT/UWP is guaranteed to be fired after final visual tree construction. There was event race condition in Silverlight implementation of Xaml UI, but no such issues on WinRT/UWP (according to MSDN)
### HamburgerMenu

Moved these calls from `LayoutUpdated` event handler to `Loaded` event handler because it's anyway one-shot event and is needed to be called after visual tree is finally constructed. `Loaded` event handler is a safe place to do it.

``` C#
UpdateVisualStates();
UpdateControl();
```
### NavButtonBehavior

Most heavily changed class.

Fixed some bugs and potentially risky places. For example, `BootStrapper.Current.ShellBackButtonUpdated` event handler was attached in both `Attach`
 and `Detach` methods. Copy/paste without change of `+=` to `-=` in `Detach` method probably a cause 😄 
Fixed potentially incorrect behavior if `Frame` property is changed at run-time.

``` C#
        private static void FrameChanged(DependencyObject d, DependencyPropertyChangedEventArgs args)
        {
            var behavior = (NavButtonBehavior)d;
            DetachFrameEvents(behavior, args.OldValue as Frame);
            AttachFrameEvents(behavior, args.NewValue as Frame);
            behavior.CalculateThrottled();
        }
```

event handlers from old Frame should be detached or there will be memory leak 

Moved dependency property changed event registration handles into private class

``` C#
        private class FrameEventRegistration
        {
            public long GoBackReg;
            public long GoForwardReg;
        }
```

and used `ConditionalWeakTable` to bind this frame registration to `Frame` instance itself - just to be sure if we removing handlers from a correct `Frame` instance

Attached handler to `Frame.Navigated` event to update navigation buttons visibility after obvious event of frame navigation.

Attached handler to `DeviceUtils.Changed` event  to update navigation buttons visibility after change of device disposition. For example, after going to full screen window mode or to continuum mode on mobile device.

Attached handler to `Frame.Loaded` event to update navigation buttons visibility after frame visual tree initialization is complete.

As I think, handling of `Frame.Navigated`, `DeviceUtils.Changed`, `Frame.Loaded` is enough to cover all possible triggers which can require navigation buttons visibility refresh.

As a minor code refactoring moved button visibility logic into static class `NavButtonsHelper` because public static methods shouldn't be declared inside non-static class if they don't return nor accept as a parameter such non-static class instance references. 
