### PR TITLE
Nag service

### DIFF
--- a/Template10 (Services)/MarketplaceService/IMarketplaceService.cs
+++ b/Template10 (Services)/MarketplaceService/IMarketplaceService.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+
+using Template10.Services.NagService;
 
 namespace Template10.Services.MarketplaceService
 {
@@ -13,5 +11,9 @@ namespace Template10.Services.MarketplaceService
         Task LaunchAppReviewInStore();
 
         Task LaunchPublisherPageInStore();
+
+        Nag CreateAppReviewNag();
+
+        Nag CreateAppReviewNag(string message);
     }
 }

--- a/Template10 (Services)/MarketplaceService/MarketplaceService.cs
+++ b/Template10 (Services)/MarketplaceService/MarketplaceService.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 using Windows.ApplicationModel;
+
+using Template10.Services.NagService;
 
 namespace Template10.Services.MarketplaceService
 {
@@ -19,6 +17,17 @@ namespace Template10.Services.MarketplaceService
             await _helper.LaunchAppReviewInStoreByProductFamilyName(Package.Current.Id.FamilyName);        
 
         public async Task LaunchPublisherPageInStore() =>
-            await _helper.LaunchPublisherPageInStore(Package.Current.Id.Publisher);        
+            await _helper.LaunchPublisherPageInStore(Package.Current.Id.Publisher);
+
+        public Nag CreateAppReviewNag() => CreateAppReviewNag($"Would you mind reviewing {Package.Current.DisplayName}?");
+
+        public Nag CreateAppReviewNag(string message)
+        {
+            return new Nag("AppReviewNag", message, async () => await this.LaunchAppReviewInStore())
+            {
+                Title = $"Review {Package.Current.DisplayName}",
+                AcceptText = "Review app"
+            };
+        }
     }
 }

--- a/Template10 (Services)/MarketplaceService/MarketplaceService.cs
+++ b/Template10 (Services)/MarketplaceService/MarketplaceService.cs
@@ -8,7 +8,7 @@ using Windows.ApplicationModel;
 
 namespace Template10.Services.MarketplaceService
 {
-    public class MarketplaceService : IMarketplaceService
+    public sealed class MarketplaceService : IMarketplaceService
     {
         readonly MarketplaceHelper _helper = new MarketplaceHelper();
 

--- a/Template10 (Services)/MarketplaceService/MarketplaceService.cs
+++ b/Template10 (Services)/MarketplaceService/MarketplaceService.cs
@@ -3,6 +3,7 @@
 using Windows.ApplicationModel;
 
 using Template10.Services.NagService;
+using Template10.Services.FileService;
 
 namespace Template10.Services.MarketplaceService
 {
@@ -26,7 +27,8 @@ namespace Template10.Services.MarketplaceService
             return new Nag("AppReviewNag", message, async () => await this.LaunchAppReviewInStore())
             {
                 Title = $"Review {Package.Current.DisplayName}",
-                AcceptText = "Review app"
+                AcceptText = "Review app",
+                Location = StorageStrategies.Roaming
             };
         }
     }

--- a/Template10 (Services)/NagService/INagService.cs
+++ b/Template10 (Services)/NagService/INagService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Template10.Services.NagService
+{
+    public interface INagService
+    {
+        Task Register(Nag nag, int launches, TimeSpan duration);
+
+        Task Register(Nag nag, int launches);
+
+        Task Register(Nag nag, TimeSpan duration);
+
+        Task<bool> ResponseExists(string nagId);
+
+        Task<NagResponseInfo> GetResponse(string nagId);
+
+        Task DeleteResponse(string nagId);
+    }
+}

--- a/Template10 (Services)/NagService/INagService.cs
+++ b/Template10 (Services)/NagService/INagService.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+using Template10.Services.FileService;
+
 namespace Template10.Services.NagService
 {
     /// <summary>
@@ -40,20 +42,20 @@ namespace Template10.Services.NagService
         /// </summary>
         /// <param name="nagId">The if of the <see cref="Nag"/></param>
         /// <returns>True if a <see cref="NagResponseInfo"/> exists for the nagId</returns>
-        Task<bool> ResponseExists(string nagId);
+        Task<bool> ResponseExists(string nagId, StorageStrategies location = StorageStrategies.Local);
 
         /// <summary>
         /// Gets the <see cref="NagResponseInfo"/> for the given id
         /// </summary>
         /// <param name="nagId">The if of the <see cref="Nag"/> to find</param>
         /// <returns>A <see cref="NagResponseInfo"/> or null if it doesn't exist</returns>
-        Task<NagResponseInfo> GetResponse(string nagId);
+        Task<NagResponseInfo> GetResponse(string nagId, StorageStrategies location = StorageStrategies.Local);
 
         /// <summary>
         /// Deletes persisted <see cref="NagResponseInfo"/>
         /// </summary>
         /// <param name="nagId">The id of the <see cref="Nag"/> to delete</param>
         /// <returns><see cref="Task"/></returns>
-        Task DeleteResponse(string nagId);
+        Task DeleteResponse(string nagId, StorageStrategies location = StorageStrategies.Local);
     }
 }

--- a/Template10 (Services)/NagService/INagService.cs
+++ b/Template10 (Services)/NagService/INagService.cs
@@ -1,23 +1,59 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Template10.Services.NagService
 {
+    /// <summary>
+    /// Interface for service that will nag the user to perform some action
+    /// (such as reviewing an app) after a certain number of launches and/or time has
+    /// past since the first launch
+    /// </summary>
     public interface INagService
     {
+        /// <summary>
+        /// Registers and checks whether to display a nag
+        /// </summary>
+        /// <param name="nag">The <see cref="Nag"/></param>
+        /// <param name="launches">The number of app launches to pass before showing the nag</param>
+        /// <param name="duration">The amount of time to pass from the first launch before showing the nag</param>
+        /// <returns><see cref="Task"/></returns>
         Task Register(Nag nag, int launches, TimeSpan duration);
 
+        /// <summary>
+        /// Registers and checks whether to display a nag
+        /// </summary>
+        /// <param name="nag">The <see cref="Nag"/></param>
+        /// <param name="launches">The number of app launches to pass before showing the nag</param>
+        /// <returns><see cref="Task"/></returns>
         Task Register(Nag nag, int launches);
 
+        /// <summary>
+        /// Registers and checks whether to display a nag
+        /// </summary>
+        /// <param name="nag">The <see cref="Nag"/></param>
+        /// <param name="duration">The amount of time to pass from the first launch before showing the nag</param>
+        /// <returns><see cref="Task"/></returns>
         Task Register(Nag nag, TimeSpan duration);
 
+        /// <summary>
+        /// Determines if the given nag has been registered
+        /// </summary>
+        /// <param name="nagId">The if of the <see cref="Nag"/></param>
+        /// <returns>True if a <see cref="NagResponseInfo"/> exists for the nagId</returns>
         Task<bool> ResponseExists(string nagId);
 
+        /// <summary>
+        /// Gets the <see cref="NagResponseInfo"/> for the given id
+        /// </summary>
+        /// <param name="nagId">The if of the <see cref="Nag"/> to find</param>
+        /// <returns>A <see cref="NagResponseInfo"/> or null if it doesn't exist</returns>
         Task<NagResponseInfo> GetResponse(string nagId);
 
+        /// <summary>
+        /// Deletes persisted <see cref="NagResponseInfo"/>
+        /// </summary>
+        /// <param name="nagId">The id of the <see cref="Nag"/> to delete</param>
+        /// <returns><see cref="Task"/></returns>
         Task DeleteResponse(string nagId);
     }
 }

--- a/Template10 (Services)/NagService/Nag.cs
+++ b/Template10 (Services)/NagService/Nag.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+using Template10.Services.FileService;
+
 namespace Template10.Services.NagService
 {
     /// <summary>
@@ -64,5 +66,10 @@ namespace Template10.Services.NagService
         /// The text to display on the defer button
         /// </summary>
         public string DeferText { get; set; } = "Not now";
+
+        /// <summary>
+        /// Flag indicating whether the user response is local to the deivce or roams with the app
+        /// </summary>
+        public StorageStrategies Location { get; set; }
     }
 }

--- a/Template10 (Services)/NagService/Nag.cs
+++ b/Template10 (Services)/NagService/Nag.cs
@@ -1,17 +1,9 @@
 ﻿using System;
 
-using Windows.Security.Cryptography;
-using Windows.Security.Cryptography.Core;
-
 namespace Template10.Services.NagService
 {
     public class Nag
     {
-        public Nag(string message, Action nagAction)
-            : this(HashText(message), message, nagAction)
-        {
-        }
-
         public Nag(string id, string message, Action nagAction)
         {
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("id cannot be null or empty", "id");
@@ -38,19 +30,5 @@ namespace Template10.Services.NagService
         public string AcceptText { get; set; } = "Yes";
 
         public string DeferText { get; set; } = "Not now";
-
-        private static string HashText(string text)
-        {
-            if (string.IsNullOrEmpty(text))
-            {
-                return string.Empty;
-            }
-
-            var buffer = CryptographicBuffer.ConvertStringToBinary(text, BinaryStringEncoding.Utf8);
-            var hashAlgorithmProvider = HashAlgorithmProvider.OpenAlgorithm(HashAlgorithmNames.Sha1);
-            var bufferHash = hashAlgorithmProvider.HashData(buffer);
-
-            return CryptographicBuffer.EncodeToHexString(bufferHash);
-        }
     }
 }

--- a/Template10 (Services)/NagService/Nag.cs
+++ b/Template10 (Services)/NagService/Nag.cs
@@ -2,8 +2,17 @@
 
 namespace Template10.Services.NagService
 {
+    /// <summary>
+    /// Information about a nag
+    /// </summary>
     public class Nag
     {
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="id"><see cref="Nag.Id"/></param>
+        /// <param name="message"><see cref="Nag.Message"/></param>
+        /// <param name="nagAction"><see cref="Nag.NagAction"/></param>
         public Nag(string id, string message, Action nagAction)
         {
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("id cannot be null or empty", "id");
@@ -15,20 +24,45 @@ namespace Template10.Services.NagService
             NagAction = nagAction;
         }
 
+        /// <summary>
+        /// The unique id for this nag
+        /// Must be unique within the context of an app
+        /// </summary>
         public string Id { get; private set; }
 
+        /// <summary>
+        /// The message to nag the user with
+        /// </summary>
         public string Message { get; private set; }
 
+        /// <summary>
+        /// The action to perform if the user accepts the nag
+        /// </summary>
         public Action NagAction { get; private set; }
 
+        /// <summary>
+        /// The title of the nag to display
+        /// </summary>
         public string Title { get; set; }
 
+        /// <summary>
+        /// Flag indicating if the user can defer the <see cref="NagAction"/> until later
+        /// </summary>
         public bool AllowDefer { get; set; }
 
+        /// <summary>
+        /// The text to display on the decline button
+        /// </summary>
         public string DeclineText { get; set; } = "No, thanks";
 
+        /// <summary>
+        /// The text to display on the accept button
+        /// </summary>
         public string AcceptText { get; set; } = "Yes";
 
+        /// <summary>
+        /// The text to display on the defer button
+        /// </summary>
         public string DeferText { get; set; } = "Not now";
     }
 }

--- a/Template10 (Services)/NagService/Nag.cs
+++ b/Template10 (Services)/NagService/Nag.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+using Windows.Security.Cryptography;
+using Windows.Security.Cryptography.Core;
+
+namespace Template10.Services.NagService
+{
+    public class Nag
+    {
+        public Nag(string message, Action nagAction)
+            : this(HashText(message), message, nagAction)
+        {
+        }
+
+        public Nag(string id, string message, Action nagAction)
+        {
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("id cannot be null or empty", "id");
+            if (string.IsNullOrEmpty(message)) throw new ArgumentException("message cannot be null or empty", "message");
+            if (nagAction == null) throw new ArgumentNullException("nagAction");
+
+            Id = id;
+            Message = message;
+            NagAction = nagAction;
+        }
+
+        public string Id { get; private set; }
+
+        public string Message { get; private set; }
+
+        public Action NagAction { get; private set; }
+
+        public string Title { get; set; }
+
+        public bool AllowDefer { get; set; }
+
+        public string DeclineText { get; set; } = "No, thanks";
+
+        public string AcceptText { get; set; } = "Yes";
+
+        public string DeferText { get; set; } = "Not now";
+
+        private static string HashText(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return string.Empty;
+            }
+
+            var buffer = CryptographicBuffer.ConvertStringToBinary(text, BinaryStringEncoding.Utf8);
+            var hashAlgorithmProvider = HashAlgorithmProvider.OpenAlgorithm(HashAlgorithmNames.Sha1);
+            var bufferHash = hashAlgorithmProvider.HashData(buffer);
+
+            return CryptographicBuffer.EncodeToHexString(bufferHash);
+        }
+    }
+}

--- a/Template10 (Services)/NagService/Nag.cs
+++ b/Template10 (Services)/NagService/Nag.cs
@@ -70,6 +70,6 @@ namespace Template10.Services.NagService
         /// <summary>
         /// Flag indicating whether the user response is local to the deivce or roams with the app
         /// </summary>
-        public StorageStrategies Location { get; set; }
+        public StorageStrategies Location { get; set; } = StorageStrategies.Local;
     }
 }

--- a/Template10 (Services)/NagService/NagResponseInfo.cs
+++ b/Template10 (Services)/NagService/NagResponseInfo.cs
@@ -69,8 +69,7 @@ namespace Template10.Services.NagService
         /// </summary>
         public bool IsAwaitingResponse
         {
-            get { return LastResponse != NagResponse.Accept && LastResponse != NagResponse.Decline; }
-            
+            get { return LastResponse != NagResponse.Accept && LastResponse != NagResponse.Decline; }            
         }
 
         /// <summary>

--- a/Template10 (Services)/NagService/NagResponseInfo.cs
+++ b/Template10 (Services)/NagService/NagResponseInfo.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+namespace Template10.Services.NagService
+{
+    public enum NagResponse
+    {
+        NoResponse,
+        Accept,
+        Decline,
+        Defer
+    }
+
+    public class NagResponseInfo 
+    {
+        public string NagId { get; set; }
+
+        public bool Suppress { get; set; }
+
+        public int LaunchCount { get; set; }
+
+        public DateTimeOffset RegistrationTimeStamp { get; set; } = DateTimeOffset.UtcNow;
+
+        public NagResponse LastResponse { get; set; } = NagResponse.NoResponse;
+
+        public DateTimeOffset LastNag { get; set; } = DateTimeOffset.MaxValue;
+
+        public bool ShouldNag(int launches)
+        {
+            return (!Suppress && LastResponse != NagResponse.Accept && LastResponse != NagResponse.Decline)
+                && (launches <= 0 || LaunchCount > launches);
+        }
+
+        public bool ShouldNag(TimeSpan duration)
+        {
+            return (!Suppress && LastResponse != NagResponse.Accept && LastResponse != NagResponse.Decline)
+                && (duration <= TimeSpan.Zero || DateTimeOffset.UtcNow > RegistrationTimeStamp + duration);
+        }
+
+        public NagResponseInfo Increment()
+        {
+            var clone = (NagResponseInfo)MemberwiseClone();
+            clone.LaunchCount++;
+            return clone;
+        }
+    }
+}

--- a/Template10 (Services)/NagService/NagResponseInfo.cs
+++ b/Template10 (Services)/NagService/NagResponseInfo.cs
@@ -24,6 +24,11 @@ namespace Template10.Services.NagService
 
         public DateTimeOffset LastNag { get; set; } = DateTimeOffset.MaxValue;
 
+        public bool IsAwaitingResponse
+        {
+            get { return LastResponse != NagResponse.Accept && LastResponse != NagResponse.Decline; }
+            
+        }
         public bool ShouldNag(int launches)
         {
             return (!Suppress && LastResponse != NagResponse.Accept && LastResponse != NagResponse.Decline)

--- a/Template10 (Services)/NagService/NagResponseInfo.cs
+++ b/Template10 (Services)/NagService/NagResponseInfo.cs
@@ -2,50 +2,99 @@
 
 namespace Template10.Services.NagService
 {
+    /// <summary>
+    /// Indicator of how the user responded to a <see cref="Nag"/>
+    /// </summary>
     public enum NagResponse
     {
+        /// <summary>
+        /// No response has been given (usually means the nag hasn't been shown)
+        /// </summary>
         NoResponse,
+
+        /// <summary>
+        /// The user performend the <see cref="Nag.NagAction"/>
+        /// </summary>
         Accept,
+
+        /// <summary>
+        /// The user declined the nag
+        /// </summary>
         Decline,
+
+        /// <summary>
+        /// The user deferred the nag
+        /// </summary>
         Defer
     }
 
+    /// <summary>
+    /// Information about a <see cref="Nag"/> registration state and the user's response
+    /// </summary>
     public class NagResponseInfo 
     {
+        /// <summary>
+        /// The unique id of the associated <see cref="Nag"/>
+        /// </summary>
         public string NagId { get; set; }
 
+        /// <summary>
+        /// Flag indicating to neevr show the nag 
+        /// (usually means an error occured deserializing this instance)
+        /// </summary>
         public bool Suppress { get; set; }
 
+        /// <summary>
+        /// The number of times the app has been launched and the <see cref="Nag"/> registered
+        /// </summary>
         public int LaunchCount { get; set; }
 
+        /// <summary>
+        /// Timestamp of when the <see cref="Nag"/> was first registered
+        /// </summary>
         public DateTimeOffset RegistrationTimeStamp { get; set; } = DateTimeOffset.UtcNow;
 
+        /// <summary>
+        /// The last response given by the user, if any
+        /// </summary>
         public NagResponse LastResponse { get; set; } = NagResponse.NoResponse;
 
+        /// <summary>
+        /// Timestamp of when the user was last nagged
+        /// </summary>
         public DateTimeOffset LastNag { get; set; } = DateTimeOffset.MaxValue;
 
+        /// <summary>
+        /// Flag indicating that the user has not accepted or declined the nag
+        /// </summary>
         public bool IsAwaitingResponse
         {
             get { return LastResponse != NagResponse.Accept && LastResponse != NagResponse.Decline; }
             
         }
+
+        /// <summary>
+        /// Determines if the <see cref="Nag"/> should be shown
+        /// </summary>
+        /// <param name="launches">The number of app launches to wait for</param>
+        /// <returns>True if launches is greater or equal to <see cref="NagResponseInfo.LaunchCount"/>
+        /// or launches equals 0</returns>
         public bool ShouldNag(int launches)
         {
             return (!Suppress && LastResponse != NagResponse.Accept && LastResponse != NagResponse.Decline)
                 && (launches <= 0 || LaunchCount > launches);
         }
 
+        /// <summary>
+        /// Determines if the <see cref="Nag"/> should be shown
+        /// </summary>
+        /// <param name="duration">The amount of time to wait after the first registartion before showing the <see cref="Nag"/></param>
+        /// <returns>True if duration is greater or equal to <see cref="DateTimeOffset.UtcNow"/> + <see cref="NagResponseInfo.RegistrationTimeStamp"/>
+        /// or duration equals <see cref="TimeSpan.Zero"/></returns>
         public bool ShouldNag(TimeSpan duration)
         {
             return (!Suppress && LastResponse != NagResponse.Accept && LastResponse != NagResponse.Decline)
                 && (duration <= TimeSpan.Zero || DateTimeOffset.UtcNow > RegistrationTimeStamp + duration);
-        }
-
-        public NagResponseInfo Increment()
-        {
-            var clone = (NagResponseInfo)MemberwiseClone();
-            clone.LaunchCount++;
-            return clone;
         }
     }
 }

--- a/Template10 (Services)/NagService/NagService.cs
+++ b/Template10 (Services)/NagService/NagService.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Template10.Services.DialogService;
+using Template10.Services.FileService;
+
+namespace Template10.Services.NagService
+{
+    public sealed class NagService : INagService
+    {
+        readonly NagServiceHelper _nagHelper;
+
+        public NagService(IDialogService dialogService, IFileService fileService)
+        {
+            _nagHelper = new NagServiceHelper(dialogService, fileService);
+        }
+
+        public async Task DeleteResponse(string nagId) => await _nagHelper.Delete(nagId);
+
+        public async Task<bool> ResponseExists(string nagId) => await _nagHelper.Exists(nagId);
+
+        public async Task<NagResponseInfo> GetResponse(string nagId) => await _nagHelper.Load(nagId);
+
+        public async Task Register(Nag nag, TimeSpan duration) => await _nagHelper.Register(nag, duration);
+
+        public async Task Register(Nag nag, int launches) => await _nagHelper.Register(nag, launches);
+
+        public async Task Register(Nag nag, int launches, TimeSpan duration) => await _nagHelper.Register(nag, launches, duration);
+    }
+}

--- a/Template10 (Services)/NagService/NagService.cs
+++ b/Template10 (Services)/NagService/NagService.cs
@@ -18,11 +18,11 @@ namespace Template10.Services.NagService
             _nagHelper = new NagServiceHelper(dialogService, fileService);
         }
 
-        public async Task DeleteResponse(string nagId) => await _nagHelper.Delete(nagId);
+        public async Task DeleteResponse(string nagId, StorageStrategies location = StorageStrategies.Local) => await _nagHelper.Delete(nagId, location);
 
-        public async Task<bool> ResponseExists(string nagId) => await _nagHelper.Exists(nagId);
+        public async Task<bool> ResponseExists(string nagId, StorageStrategies location = StorageStrategies.Local) => await _nagHelper.Exists(nagId, location);
 
-        public async Task<NagResponseInfo> GetResponse(string nagId) => await _nagHelper.Load(nagId);
+        public async Task<NagResponseInfo> GetResponse(string nagId, StorageStrategies location = StorageStrategies.Local) => await _nagHelper.Load(nagId, location);
 
         public async Task Register(Nag nag, TimeSpan duration) => await _nagHelper.Register(nag, duration);
 

--- a/Template10 (Services)/NagService/NagService.cs
+++ b/Template10 (Services)/NagService/NagService.cs
@@ -6,6 +6,9 @@ using Template10.Services.FileService;
 
 namespace Template10.Services.NagService
 {
+    /// <summary>
+    /// <see cref="INagService"/>
+    /// </summary>
     public sealed class NagService : INagService
     {
         readonly NagServiceHelper _nagHelper;

--- a/Template10 (Services)/NagService/NagServiceHelper.cs
+++ b/Template10 (Services)/NagService/NagServiceHelper.cs
@@ -24,14 +24,14 @@ namespace Template10.Services.NagService
             _fileService = fileService;
         }
 
-        public async Task<bool> Exists(string nagId)
+        public async Task<bool> Exists(string nagId, StorageStrategies location = StorageStrategies.Local)
         {
             if (string.IsNullOrEmpty(nagId)) throw new ArgumentException("nagId cannot be null or empty", "nagId");
 
-            return await _fileService.FileExistsAsync(string.Format(StateFileNameTemplate, nagId), StorageStrategies.Roaming);
+            return await _fileService.FileExistsAsync(string.Format(StateFileNameTemplate, nagId), location);
         }
 
-        public async Task<NagResponseInfo> Load(string nagId)
+        public async Task<NagResponseInfo> Load(string nagId, StorageStrategies location = StorageStrategies.Local)
         {
             if (string.IsNullOrEmpty(nagId)) throw new ArgumentException("nagId cannot be null or empty", "nagId");
 
@@ -39,7 +39,7 @@ namespace Template10.Services.NagService
             {
                 if (await Exists(nagId))
                 {
-                    return await _fileService.ReadFileAsync<NagResponseInfo>(GetFileName(nagId), StorageStrategies.Roaming);
+                    return await _fileService.ReadFileAsync<NagResponseInfo>(GetFileName(nagId), location);
                 }
 
                 return new NagResponseInfo() { NagId = nagId };
@@ -52,19 +52,19 @@ namespace Template10.Services.NagService
             }
         }
 
-        public async Task Delete(string nagId)
+        public async Task Delete(string nagId, StorageStrategies location = StorageStrategies.Local)
         {
             if (string.IsNullOrEmpty(nagId)) throw new ArgumentException("nagId cannot be null or empty", "nagId");
 
-            await _fileService.DeleteFileAsync(GetFileName(nagId), StorageStrategies.Roaming);
+            await _fileService.DeleteFileAsync(GetFileName(nagId), location);
         }
 
-        public async Task Persist(NagResponseInfo state, string nagId)
+        public async Task Persist(NagResponseInfo state, string nagId, StorageStrategies location = StorageStrategies.Local)
         {
             if (state == null) throw new ArgumentNullException("state");
             if (string.IsNullOrEmpty(nagId)) throw new ArgumentException("nagId cannot be null or empty", "nagId");
 
-            await _fileService.WriteFileAsync<NagResponseInfo>(GetFileName(nagId), state, StorageStrategies.Roaming);
+            await _fileService.WriteFileAsync<NagResponseInfo>(GetFileName(nagId), state, location);
         }
 
         public async Task Register(Nag nag, int launches)
@@ -80,7 +80,7 @@ namespace Template10.Services.NagService
             }
             else if (responseInfo.IsAwaitingResponse)
             {
-                await Persist(responseInfo, nag.Id);
+                await Persist(responseInfo, nag.Id, nag.Location);
             }
         }
 
@@ -97,7 +97,7 @@ namespace Template10.Services.NagService
             }
             else if (responseInfo.IsAwaitingResponse)
             {
-                await Persist(responseInfo, nag.Id);
+                await Persist(responseInfo, nag.Id, nag.Location);
             }
         }
 
@@ -114,7 +114,7 @@ namespace Template10.Services.NagService
             }
             else if (responseInfo.IsAwaitingResponse)
             {
-                await Persist(responseInfo, nag.Id);
+                await Persist(responseInfo, nag.Id, nag.Location);
             }
         }
 
@@ -135,7 +135,7 @@ namespace Template10.Services.NagService
             responseInfo.LastResponse = response;
             responseInfo.LastNag = DateTimeOffset.UtcNow;
 
-            await Persist(responseInfo, nag.Id);
+            await Persist(responseInfo, nag.Id, nag.Location);
         }
 
         private async Task<NagResponse> ShowNag(Nag nag)

--- a/Template10 (Services)/NagService/NagServiceHelper.cs
+++ b/Template10 (Services)/NagService/NagServiceHelper.cs
@@ -78,7 +78,7 @@ namespace Template10.Services.NagService
             {
                 await ProcessNag(nag, responseInfo);
             }
-            else if (responseInfo.LastResponse == NagResponse.NoResponse)
+            else if (responseInfo.IsAwaitingResponse)
             {
                 await Persist(responseInfo, nag.Id);
             }
@@ -95,7 +95,7 @@ namespace Template10.Services.NagService
             {
                 await ProcessNag(nag, responseInfo);
             }
-            else if (responseInfo.LastResponse == NagResponse.NoResponse)
+            else if (responseInfo.IsAwaitingResponse)
             {
                 await Persist(responseInfo, nag.Id);
             }
@@ -112,7 +112,7 @@ namespace Template10.Services.NagService
             {
                 await ProcessNag(nag, responseInfo);
             }
-            else if (responseInfo.LastResponse == NagResponse.NoResponse)
+            else if (responseInfo.IsAwaitingResponse)
             {
                 await Persist(responseInfo, nag.Id);
             }

--- a/Template10 (Services)/NagService/NagServiceHelper.cs
+++ b/Template10 (Services)/NagService/NagServiceHelper.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Windows.UI.Popups;
+
+using Template10.Services.DialogService;
+using Template10.Services.FileService;
+
+namespace Template10.Services.NagService
+{
+    public class NagServiceHelper
+    {
+        readonly IDialogService _dialogService;
+        readonly IFileService _fileService;
+
+        const string StateFileNameTemplate = "Template10.Services.NagService.{0}.json";
+
+        public NagServiceHelper(IDialogService dialogService, IFileService fileService)
+        {
+            if (dialogService == null) throw new ArgumentNullException("dialogService");
+            if (fileService == null) throw new ArgumentNullException("fileService");
+
+            _dialogService = dialogService;
+            _fileService = fileService;
+        }
+
+        public async Task<bool> Exists(string nagId)
+        {
+            if (string.IsNullOrEmpty(nagId)) throw new ArgumentException("nagId cannot be null or empty", "nagId");
+
+            return await _fileService.FileExistsAsync(string.Format(StateFileNameTemplate, nagId), StorageStrategies.Roaming);
+        }
+
+        public async Task<NagResponseInfo> Load(string nagId)
+        {
+            if (string.IsNullOrEmpty(nagId)) throw new ArgumentException("nagId cannot be null or empty", "nagId");
+
+            try
+            {
+                if (await Exists(nagId))
+                {
+                    return await _fileService.ReadFileAsync<NagResponseInfo>(GetFileName(nagId), StorageStrategies.Roaming);
+                }
+
+                return new NagResponseInfo() { NagId = nagId };
+            }
+            catch
+            {
+                // if we are having trouble loading the response, suppress any nags
+                // this should prevent nagging repeatedly because of an unknown error 
+                return new NagResponseInfo() { Suppress = true };
+            }
+        }
+
+        public async Task Delete(string nagId)
+        {
+            if (string.IsNullOrEmpty(nagId)) throw new ArgumentException("nagId cannot be null or empty", "nagId");
+
+            await _fileService.DeleteFileAsync(GetFileName(nagId), StorageStrategies.Roaming);
+        }
+
+        public async Task Persist(NagResponseInfo state, string nagId)
+        {
+            if (state == null) throw new ArgumentNullException("state");
+            if (string.IsNullOrEmpty(nagId)) throw new ArgumentException("nagId cannot be null or empty", "nagId");
+
+            await _fileService.WriteFileAsync<NagResponseInfo>(GetFileName(nagId), state, StorageStrategies.Roaming);
+        }
+
+        public async Task Register(Nag nag, int launches)
+        {
+            if (nag == null) throw new ArgumentNullException("nag");
+
+            var responseInfo = await Load(nag.Id);
+            responseInfo.LaunchCount++;
+
+            if (responseInfo.ShouldNag(launches))
+            {
+                await ProcessNag(nag, responseInfo);
+            }
+            else if (responseInfo.LastResponse == NagResponse.NoResponse)
+            {
+                await Persist(responseInfo, nag.Id);
+            }
+        }
+
+        public async Task Register(Nag nag, TimeSpan duration)
+        {
+            if (nag == null) throw new ArgumentNullException("nag");
+
+            var responseInfo = await Load(nag.Id);
+            responseInfo.LaunchCount++;
+
+            if (responseInfo.ShouldNag(duration))
+            {
+                await ProcessNag(nag, responseInfo);
+            }
+            else if (responseInfo.LastResponse == NagResponse.NoResponse)
+            {
+                await Persist(responseInfo, nag.Id);
+            }
+        }
+
+        public async Task Register(Nag nag, int launches, TimeSpan duration)
+        {
+            if (nag == null) throw new ArgumentNullException("nag");
+
+            var responseInfo = await Load(nag.Id);
+            responseInfo.LaunchCount++;
+
+            if (responseInfo.ShouldNag(launches) && responseInfo.ShouldNag(duration))
+            {
+                await ProcessNag(nag, responseInfo);
+            }
+            else if (responseInfo.LastResponse == NagResponse.NoResponse)
+            {
+                await Persist(responseInfo, nag.Id);
+            }
+        }
+
+        private async Task ProcessNag(Nag nag, NagResponseInfo responseInfo)
+        {
+            var response = await ShowNag(nag);
+
+            if (response == NagResponse.Accept)
+            {
+                nag.NagAction();
+            }
+            else if (response == NagResponse.Defer)
+            {
+                responseInfo.LaunchCount = 0;
+                responseInfo.RegistrationTimeStamp = DateTimeOffset.UtcNow;
+            }
+
+            responseInfo.LastResponse = response;
+            responseInfo.LastNag = DateTimeOffset.UtcNow;
+
+            await Persist(responseInfo, nag.Id);
+        }
+
+        private async Task<NagResponse> ShowNag(Nag nag)
+        {
+            var response = NagResponse.NoResponse;
+            if (nag.AllowDefer)
+            {
+                await _dialogService.ShowAsync(nag.Message, nag.Title,
+                    new UICommand(nag.AcceptText, command => response = NagResponse.Accept),
+                    new UICommand(nag.DeclineText, command => response = NagResponse.Decline),
+                    new UICommand(nag.DeferText, command => response = NagResponse.Defer));
+            }
+            else
+            {
+                await _dialogService.ShowAsync(nag.Message, nag.Title,
+                    new UICommand(nag.AcceptText, command => response = NagResponse.Accept),
+                    new UICommand(nag.DeclineText, command => response = NagResponse.Decline));
+            }
+
+            return response;
+        }
+
+        private static string GetFileName(string nagId)
+        {
+            return string.Format(StateFileNameTemplate, nagId);
+        }
+    }
+}

--- a/Template10 (Services)/Template10 (Services).csproj
+++ b/Template10 (Services)/Template10 (Services).csproj
@@ -152,6 +152,11 @@
     <Compile Include="MarketplaceService\IMarketplaceService.cs" />
     <Compile Include="MarketplaceService\MarketplaceHelper.cs" />
     <Compile Include="MarketplaceService\MarketplaceService.cs" />
+    <Compile Include="NagService\INagService.cs" />
+    <Compile Include="NagService\Nag.cs" />
+    <Compile Include="NagService\NagResponseInfo.cs" />
+    <Compile Include="NagService\NagService.cs" />
+    <Compile Include="NagService\NagServiceHelper.cs" />
     <Compile Include="NetworkAvailableService\INetworkAvailableService.cs" />
     <Compile Include="NetworkAvailableService\NetworkAvailableHelper.cs" />
     <Compile Include="NetworkAvailableService\NetworkAvailableService.cs" />


### PR DESCRIPTION
Implementation of an NagService https://github.com/Windows-XAML/Template10/issues/1103

Some notes on the code
- state is persisted in a file. 1 file per unique nag id. `ISettingService`might be a better way to manage this but services doesn't have a reference to library
- Added helper method in marketplace service to easily create an app review nag
- State can be persisted locally or in roaming profile. Roaming is useful for app review nags where you probably don't want to nag the user on every device once they have responded). I used the `StorageStrategies`enum from `FileService`to indicate this. Not sure how you feel about this sort of type dependency so can change it if that smells.
