### PR TITLE
Adds MenuGroup dependency property to facilitate submenu implementation.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerButtonInfo.cs
+++ b/Template10 (Library)/Controls/HamburgerButtonInfo.cs
@@ -69,6 +69,22 @@ namespace Template10.Controls
           typeof(HamburgerButtonInfo), new PropertyMetadata(null));
 
         /// <summary>
+        /// Sets and gets the MenuGroup property.
+        /// In simplest form, a Command Button acting as a parent menu can handle its Tapped event in such a way that 
+        /// the remaining group members are submenu children. This parent can then act upon its children, such as toggling
+        /// their visibility. You can, no doubt, find other more advanced uses for this though haven't figured out one yet ...
+        /// 
+        /// </summary>  
+        public object MenuGroup
+        {
+            get { return GetValue(MenuGroupProperty); }
+            set { SetValue(MenuGroupProperty, value); }
+        }
+        public static readonly DependencyProperty MenuGroupProperty =
+          DependencyProperty.Register(nameof(CommandParameter), typeof(object),
+          typeof(HamburgerButtonInfo), new PropertyMetadata(null));
+
+        /// <summary>
         /// Sets and gets the PageType property.
         /// </summary>
         public Type PageType


### PR DESCRIPTION
### This is now for background information only. The PR in here  is superseded by #1120.

---
### Background

See the demo by @JerryNixon in #1106.
### Description

You'll notice that the submenu demo in #1106 is a joy to have with T10 and it really adds that vital feature for organizing related submenu commands as a group. This PR simply adds a dependency property that makes programming a bit easier (for a start, this avoids hard-wiring to submenu button's `x:Name`). With **MenuGroup** dp, you add an identifier using **MenuGroup** to menu commands in a group  -- example `MenuGroup="FolderCommand"` in `Shell.xaml`. A command button in a group that handles the `Tapped` event will be parent command while the rest in the group will be submenu children upon which the parent will act, for instance to toggle their visibility.

In the example below, all `HamburgerButtonInfo` buttons have the same non-null `MenuGroup` string value (doesn't even matter what the string is but group command name for sake of documentation).

There is no prescriptive rule here in using `MenuGroup` really-- it's up to you how to use the identifier based on your own logic. For example, the command button that acts as parent can ignore setting its own `MenuGroup`, with `Tapped` event handling by parent being sufficient. That way you avoid the `!x.Equals(hbi) &&` logic in the LINQ statement altogether but you need to use a constant string in place of `menuGroupLabel` derived from the parent command button. 

```
private void Folders_Tapped(object sender, RoutedEventArgs e)
{
    var hbi = (sender as HamburgerButtonInfo);

    string menuGroupLabel = hbi?.MenuGroup?.ToString();
    if (menuGroupLabel == null) return;  // shouldn't normally happen, but better safe than ;-(

    List<HamburgerButtonInfo> subMenuButtons = HamburgerMenu.PrimaryButtons.Select(x => x).Where(x => (!x.Equals(hbi) && x.MenuGroup?.ToString() == menuGroupLabel)).ToList();
    if (subMenuButtons.Count == 0) return;  // shouldn't normally happen, but better safe than ;-(

    // Get a peek of what current visibility state is for submenus
    Visibility newVis = (subMenuButtons[0].Visibility == Visibility.Visible) ? Visibility.Collapsed : Visibility.Visible;

    // Use for loop instead of foreach, whenever possible
    for (int i = 0; i < subMenuButtons.Count; i++)
    {
        subMenuButtons[i].Visibility = newVis;
    }
}
```
