### PR TITLE
Updated version of PR #1114.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerButtonInfo.cs
+++ b/Template10 (Library)/Controls/HamburgerButtonInfo.cs
@@ -69,6 +69,22 @@ namespace Template10.Controls
           typeof(HamburgerButtonInfo), new PropertyMetadata(null));
 
         /// <summary>
+        /// Sets and gets the GroupName property.
+        /// In simplest form, a NavButton acting as a parent menu handles its Tapped event with the remaining group 
+        /// members as submenu children. This parent can then act upon its children, such as toggling their visibility.
+        /// You can, no doubt, find other more advanced uses for this though haven't figured out one yet ...
+        /// 
+        /// </summary>  
+        public object GroupName
+        {
+            get { return GetValue(GroupNameProperty); }
+            set { SetValue(GroupNameProperty, value); }
+        }
+        public static readonly DependencyProperty GroupNameProperty =
+          DependencyProperty.Register(nameof(CommandParameter), typeof(object),
+          typeof(HamburgerButtonInfo), new PropertyMetadata(null));
+
+        /// <summary>
         /// Sets and gets the PageType property.
         /// </summary>
         public Type PageType

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -649,7 +649,6 @@ namespace Template10.Controls
         #region Nav Buttons
 
         #region commands
-        public event EventHandler CommandButttonTapped;
         Mvvm.DelegateCommand _hamburgerCommand;
         internal Mvvm.DelegateCommand HamburgerCommand => _hamburgerCommand ?? (_hamburgerCommand = new Mvvm.DelegateCommand(ExecuteHamburger));
         void ExecuteHamburger()
@@ -678,7 +677,6 @@ namespace Template10.Controls
             {
                 ExecuteNavButtonICommand(commandInfo);
                 commandInfo.RaiseTapped(new RoutedEventArgs());
-                CommandButttonTapped?.Invoke(commandInfo, null);
             }
         }
         #endregion

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -649,7 +649,7 @@ namespace Template10.Controls
         #region Nav Buttons
 
         #region commands
-
+        public event EventHandler CommandButttonTapped;
         Mvvm.DelegateCommand _hamburgerCommand;
         internal Mvvm.DelegateCommand HamburgerCommand => _hamburgerCommand ?? (_hamburgerCommand = new Mvvm.DelegateCommand(ExecuteHamburger));
         void ExecuteHamburger()
@@ -678,9 +678,9 @@ namespace Template10.Controls
             {
                 ExecuteNavButtonICommand(commandInfo);
                 commandInfo.RaiseTapped(new RoutedEventArgs());
+                CommandButttonTapped?.Invoke(commandInfo, null);
             }
         }
-
         #endregion
 
         int NavButtonCount => PrimaryButtons.Count + SecondaryButtons.Count;

--- a/Template10 (Library)/Utils/XamlUtils.cs
+++ b/Template10 (Library)/Utils/XamlUtils.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Template10.Controls;
 
 namespace Template10.Utils
 {
@@ -132,6 +133,22 @@ namespace Template10.Utils
         {
             if (o.ReadLocalValue(dp) == DependencyProperty.UnsetValue)
                 o.SetValue(dp, value);
+        }
+
+        public static List<HamburgerButtonInfo> ItemsInGroup(this HamburgerButtonInfo button, bool IncludeSecondaryButtons = false)
+        {
+            string groupName = button.GroupName?.ToString();
+            if (string.IsNullOrWhiteSpace(groupName)) return null;
+
+            FrameworkElement fe = button.Content as FrameworkElement;
+            HamburgerMenu hamMenu = fe.FirstAncestor<HamburgerMenu>();
+
+            List<HamburgerButtonInfo> NavButtons = hamMenu.PrimaryButtons.ToList();
+            if (IncludeSecondaryButtons) NavButtons.InsertRange(NavButtons.Count, hamMenu.SecondaryButtons.ToList());
+
+            List<HamburgerButtonInfo> groupItems = NavButtons.Where(x => !x.Equals(button) && x.GroupName?.ToString() == groupName).ToList();
+
+            return groupItems;
         }
     }
 }


### PR DESCRIPTION
Updated version of PR #1114.
### Summary
- Adds a **GroupName** dependency property to facilitate submenu implementation;
- Adds an extension to get a list of submenu NavButtons.
### In XAML

**parent NavButton  (the first in the Group and must be Command button):**

```
<c:HamburgerButtonInfo GroupName="groupName" ButtonType="Command" Tapped="MenuTapped" ... >
```

**submenu NavButtons (can be any button type):**

```
<c:HamburgerButtonInfo GroupName="groupName" ... >
```
### In Codebehind

```
private void MenuTapped(object sender, RoutedEventArgs e)
{
     var hbi = (sender as HamburgerButtonInfo);
     var subMenuButtons = hbi.ItemsInGroup();

     ... // do visibility toggling on submenus (see previous example) or other operations ...
}
```
- `hbi.ItemsInGroup();` extension returns a list of submenu items (in PrimaryButtons) as `List<HamburgerButtonInfo>`.
- `hbi.ItemsInGroup(IncludeSecondaryButtons:true);` provides an option to include SecondaryButtons.
- No need to pass on the GroupName string; the extension does that job.
- No need to exclude the parent NavButton (of type Command) from the returned List; again, the extension does that job.
