### PR TITLE
Adds a HamburgerMenu-wide CommandButtonTapped event.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -649,7 +649,7 @@ namespace Template10.Controls
         #region Nav Buttons
 
         #region commands
-
+        public event EventHandler CommandButttonTapped;
         Mvvm.DelegateCommand _hamburgerCommand;
         internal Mvvm.DelegateCommand HamburgerCommand => _hamburgerCommand ?? (_hamburgerCommand = new Mvvm.DelegateCommand(ExecuteHamburger));
         void ExecuteHamburger()
@@ -678,9 +678,9 @@ namespace Template10.Controls
             {
                 ExecuteNavButtonICommand(commandInfo);
                 commandInfo.RaiseTapped(new RoutedEventArgs());
+                CommandButttonTapped?.Invoke(commandInfo, null);
             }
         }
-
         #endregion
 
         int NavButtonCount => PrimaryButtons.Count + SecondaryButtons.Count;


### PR DESCRIPTION
### Summary

Adds a HamburgerMenu-wide **CommandButtonTapped** event.
### Purpose

As we all know, NavButtons come in three kinds: Toggle, Command and Literal. Unlike the Toggle button, Command button (and Literal button), when tapped, do not set the `NavCheckedBackground` because they don't engage in page navigation, rather command execution. At times the user may find this a bit disconcerting, i.e., on tapping on a Command button, the previous NavCheckedBackground (due to ToggleButton) still stays on.

To improve on the above situation I uncheck the `NavCheckedBackground` of previous ToggleButton (you can capture this in `HamburgerMenu.SelectedChanged()` event handler and persist to a local field) in Command button's `Tapped` event handler. This can be further improved by restoring the negated NavCheckedBackground by validating the Page linked to NavCheckedBackground state is still active after command execution (end of command execution logic or a timer may be used for this).

The above workaround wrt `NavCheckedBackground`, plus the submenu enhancement currently in progress (see PR #1120, #1114 for details) suggest that it's time we have a HamburgerMenu-wide Tapped event (named as `CommandButtonTapped`) and invoked exclusively by Command buttons.
- For this, everything is _readily cooked_ in **HamburgerMenu.xaml.cs**, and only 2-line code is required.
