### PR TITLE
Adds GroupName dependency property to facilitate submenu implementation

### DIFF
--- a/Template10 (Library)/Controls/HamburgerButtonInfo.cs
+++ b/Template10 (Library)/Controls/HamburgerButtonInfo.cs
@@ -69,6 +69,22 @@ namespace Template10.Controls
           typeof(HamburgerButtonInfo), new PropertyMetadata(null));
 
         /// <summary>
+        /// Sets and gets the GroupName property.
+        /// In simplest form, a NavButton acting as a parent menu handles its Tapped event with the remaining group 
+        /// members as submenu children. This parent can then act upon its children, such as toggling their visibility.
+        /// You can, no doubt, find other more advanced uses for this though haven't figured out one yet ...
+        /// 
+        /// </summary>  
+        public object GroupName
+        {
+            get { return GetValue(GroupNameProperty); }
+            set { SetValue(GroupNameProperty, value); }
+        }
+        public static readonly DependencyProperty GroupNameProperty =
+          DependencyProperty.Register(nameof(CommandParameter), typeof(object),
+          typeof(HamburgerButtonInfo), new PropertyMetadata(null));
+
+        /// <summary>
         /// Sets and gets the PageType property.
         /// </summary>
         public Type PageType

--- a/Template10 (Library)/Utils/XamlUtils.cs
+++ b/Template10 (Library)/Utils/XamlUtils.cs
@@ -139,6 +139,7 @@ namespace Template10.Utils
         /// Returns a list of submenu buttons with the same GroupName attribute as the command button upon which this
         /// extension is invoked (which is treated as Parent command button).
         /// </summary>
+        /// <returns>List &lt; HamburgerButtonInfo &gt. List will be 0 if nothing found. </returns>
         /// <remarks>
         /// For added convenience, the GroupName attribute is detected with string.StartWith(groupName) rather than
         /// the straightforward string.Equals(groupName). That way we can tag submenu buttons as groupName1, groupName2, 
@@ -146,11 +147,12 @@ namespace Template10.Utils
         /// which in this case is groupName.
         /// You don't have to use this scheme in which case you just stick to a single groupName for all buttons.
         /// </remarks>
-        /// 
+
         public static List<HamburgerButtonInfo> ItemsInGroup(this HamburgerButtonInfo button, bool IncludeSecondaryButtons = false)
         {
             string groupName = button.GroupName?.ToString();
-            if (string.IsNullOrWhiteSpace(groupName)) return null;
+            // Return 0 count List rather than null
+            if (string.IsNullOrWhiteSpace(groupName)) return new List<HamburgerButtonInfo>();
 
             FrameworkElement fe = button.Content as FrameworkElement;
             HamburgerMenu hamMenu = fe.FirstAncestor<HamburgerMenu>();

--- a/Template10 (Library)/Utils/XamlUtils.cs
+++ b/Template10 (Library)/Utils/XamlUtils.cs
@@ -139,7 +139,7 @@ namespace Template10.Utils
         /// Returns a list of submenu buttons with the same GroupName attribute as the command button upon which this
         /// extension is invoked (which is treated as Parent command button).
         /// </summary>
-        /// <returns>List &lt; HamburgerButtonInfo &gt. List will be 0 if nothing found. </returns>
+        /// <returns>Submenu buttons in List&lt;HamburgerButtonInfo&gt;. If no submenu buttons found,  List is still returned with element count of 0. </returns>
         /// <remarks>
         /// For added convenience, the GroupName attribute is detected with string.StartWith(groupName) rather than
         /// the straightforward string.Equals(groupName). That way we can tag submenu buttons as groupName1, groupName2, 

--- a/Template10 (Library)/Utils/XamlUtils.cs
+++ b/Template10 (Library)/Utils/XamlUtils.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Template10.Controls;
 
 namespace Template10.Utils
 {
@@ -132,6 +133,34 @@ namespace Template10.Utils
         {
             if (o.ReadLocalValue(dp) == DependencyProperty.UnsetValue)
                 o.SetValue(dp, value);
+        }
+
+        /// <summary>
+        /// Returns a list of submenu buttons with the same GroupName attribute as the command button upon which this
+        /// extension is invoked (which is treated as Parent command button).
+        /// </summary>
+        /// <remarks>
+        /// For added convenience, the GroupName attribute is detected with string.StartWith(groupName) rather than
+        /// the straightforward string.Equals(groupName). That way we can tag submenu buttons as groupName1, groupName2, 
+        /// groupName3, etc. With this scheme, the parent command button should be named by subset string, 
+        /// which in this case is groupName.
+        /// You don't have to use this scheme in which case you just stick to a single groupName for all buttons.
+        /// </remarks>
+        /// 
+        public static List<HamburgerButtonInfo> ItemsInGroup(this HamburgerButtonInfo button, bool IncludeSecondaryButtons = false)
+        {
+            string groupName = button.GroupName?.ToString();
+            if (string.IsNullOrWhiteSpace(groupName)) return null;
+
+            FrameworkElement fe = button.Content as FrameworkElement;
+            HamburgerMenu hamMenu = fe.FirstAncestor<HamburgerMenu>();
+
+            List<HamburgerButtonInfo> NavButtons = hamMenu.PrimaryButtons.ToList();
+            if (IncludeSecondaryButtons) NavButtons.InsertRange(NavButtons.Count, hamMenu.SecondaryButtons.ToList());
+
+            List<HamburgerButtonInfo> groupItems = NavButtons.Where(x => !x.Equals(button) && (x.GroupName?.ToString()?.StartsWith(groupName)??false)).ToList();
+
+            return groupItems;
         }
     }
 }


### PR DESCRIPTION
### Summary
- Updated version of PR #1114.
- Adds a **GroupName** dependency property to facilitate submenu implementation;
- Adds an extension to get a list of submenu NavButtons.
### In XAML

**parent NavButton  (the first in the Group and must be Command button):**

```
<Controls:HamburgerButtonInfo GroupName="groupName" ButtonType="Command" Tapped="MenuTapped" ... >
```

**submenu NavButtons (can be any button type):**

```
<Controls:HamburgerButtonInfo GroupName="groupName" ... >
```
### In Codebehind

```
private void MenuTapped(object sender, RoutedEventArgs e)
{
     var hbi = (sender as HamburgerButtonInfo);
     var subMenuButtons = hbi.ItemsInGroup();

     ... // do visibility toggling on submenus (see previous example) or other operations ...
}
```
- `hbi.ItemsInGroup();` extension returns a list of submenu items (in PrimaryButtons) as `List<HamburgerButtonInfo>`.
- `hbi.ItemsInGroup(IncludeSecondaryButtons:true);` provides an option to include SecondaryButtons.
- No need to pass on the GroupName string; the extension does that job.
- No need to exclude the parent NavButton (of type Command) from the returned List; again, the extension does that job.
