### PR TITLE
Fix ViewLifetimeControl to have WindowsWrapper initiaized on creation

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -96,12 +96,11 @@ namespace Template10.Common
         {
             DebugWrite();
             //should be called to initialize and set new SynchronizationContext
-            ViewService.OnWindowCreated();
             if (!WindowWrapper.ActiveWrappers.Any())
                 Loaded();
-
             // handle window
             var window = new WindowWrapper(args.Window);
+            ViewService.OnWindowCreated();
             WindowCreated?.Invoke(this, args);
             base.OnWindowCreated(args);           
         }


### PR DESCRIPTION
Fix for null WindowWrapper. ViewLifetimecontrol was created before WindowWrapper initialization.
