### PR TITLE
Restores missing reference to ValueWhenConverter (see issue #1122) to SettingsPage.xaml

### DIFF
--- a/Templates (Project)/Hamburger/App.xaml
+++ b/Templates (Project)/Hamburger/App.xaml
@@ -1,8 +1,7 @@
 ﻿<common:BootStrapper x:Class="Sample.App"
                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                     xmlns:common="using:Template10.Common"
-                     xmlns:converter="using:Template10.Converters">
+                     xmlns:common="using:Template10.Common">
 
     <Application.Resources>
         <ResourceDictionary>

--- a/Templates (Project)/Hamburger/Views/SettingsPage.xaml
+++ b/Templates (Project)/Hamburger/Views/SettingsPage.xaml
@@ -16,6 +16,20 @@
         <vm:SettingsPageViewModel x:Name="ViewModel" />
     </Page.DataContext>
 
+    <Page.Resources>
+        <converter:ValueWhenConverter x:Name="FalseWhenTrueConverter">
+            <converter:ValueWhenConverter.When>
+                <x:Boolean>True</x:Boolean>
+            </converter:ValueWhenConverter.When>
+            <converter:ValueWhenConverter.Value>
+                <x:Boolean>False</x:Boolean>
+            </converter:ValueWhenConverter.Value>
+            <converter:ValueWhenConverter.Otherwise>
+                <x:Boolean>True</x:Boolean>
+            </converter:ValueWhenConverter.Otherwise>
+        </converter:ValueWhenConverter>
+    </Page.Resources>
+
     <RelativePanel Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
         <VisualStateManager.VisualStateGroups>


### PR DESCRIPTION
### Summary

Restores missing reference to `ValueWhenConverter` (see issue #1122) to SettingsPage.xaml in HamburgerMenu project.
### More Info ...

The `ValueWhenConverter` converter resource reference used to be in `App.xaml` but not anymore. I put the same resource back in the `SettingsPage.xaml` as this page is the only one using the converter.
