### PR TITLE
Avoids a possible Null Exception in JumpList Sample project by testiing for a Null File.

### DIFF
--- a/Samples/JumpList/ViewModels/MainPageViewModel.cs
+++ b/Samples/JumpList/ViewModels/MainPageViewModel.cs
@@ -50,6 +50,11 @@ namespace Template10.Samples.JumpListSample.ViewModels
 
         public async void Save()
         {
+            if (File == null)
+            {
+                await new Windows.UI.Popups.MessageDialog("No file selected.").ShowAsync();
+                return;
+            }
             try
             {
                 await _DataService.SaveFileInfoAsync(File);


### PR DESCRIPTION
### Summary

Avoids a possible Null Exception in JumpList Sample project by testiing for a Null File.
### More Info

Tapping on Save App menu button when file is not loaded throws an exception because no file exists. Either the menu button should be disabled until file is loaded or a conditional test must be in place for non-null file for the save method. This fix does the latter.
