### PR TITLE
Adds VisbilityChangeBehavior

### DIFF
--- a/Template10 (Library)/Behaviors/VisbilityChangeBehavior.cs
+++ b/Template10 (Library)/Behaviors/VisbilityChangeBehavior.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.Xaml.Interactivity;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Markup;
+
+namespace Template10.Behaviors
+{
+    [ContentProperty(Name = nameof(Actions))]
+    [TypeConstraint(typeof(FrameworkElement))]
+    public class VisbilityChangeBehavior : DependencyObject, IBehavior
+    {
+        public DependencyObject AssociatedObject { get; private set; }
+
+        // The value of visibility that triggers the behavior
+        public Visibility Visibility { get; set; } = Visibility.Visible;
+
+        private Visibility? LastKnownVisibility { get; set; }
+
+        private bool HasBeenLoaded { get; set; }
+
+        public void Attach(DependencyObject associatedObject)
+        {
+            AssociatedObject = associatedObject;
+            (AssociatedObject as FrameworkElement).LayoutUpdated += VisbilityBehavior_LayoutUpdated;
+            (AssociatedObject as FrameworkElement).Loaded += VisbilityBehavior_Loaded;
+        }
+        public void Detach()
+        {
+            (AssociatedObject as FrameworkElement).LayoutUpdated -= VisbilityBehavior_LayoutUpdated;
+            (AssociatedObject as FrameworkElement).Loaded -= VisbilityBehavior_Loaded;
+        }
+
+        private void VisbilityBehavior_Loaded(object sender, RoutedEventArgs e)
+        {
+            HasBeenLoaded = true;
+        }
+
+
+        private void VisbilityBehavior_LayoutUpdated(object sender, object e)
+        {
+            if (!HasBeenLoaded)
+                return;
+
+            var element = (AssociatedObject as FrameworkElement);
+
+            if (element?.Parent == null)
+            {
+                //If no parent navigation probably happening to a different page
+                //Clear LastKnownVisibility to make sure actions are triggered
+                //if we navigate back to page.
+                LastKnownVisibility = null;
+                HasBeenLoaded = false;
+                return;
+            }
+
+            Visibility currentVisibility = Visibility.Visible;
+            while (element != null)
+            {
+                if (element.Visibility == Visibility.Collapsed)
+                {
+                    currentVisibility = Visibility.Collapsed;
+                    break;
+                }
+
+                element = element.Parent as FrameworkElement;
+            }
+
+            if (currentVisibility != LastKnownVisibility)
+            {
+                LastKnownVisibility = currentVisibility;
+
+                if (LastKnownVisibility == Visibility)
+                {
+                    Interaction.ExecuteActions(AssociatedObject, Actions, null);
+                }
+            }
+        }
+
+        public ActionCollection Actions
+        {
+            get
+            {
+                var actions = (ActionCollection)base.GetValue(ActionsProperty);
+                if (actions == null)
+                {
+                    SetValue(ActionsProperty, actions = new ActionCollection());
+                }
+                return actions;
+            }
+        }
+        public static readonly DependencyProperty ActionsProperty =
+            DependencyProperty.Register(nameof(Actions), typeof(ActionCollection),
+                typeof(KeyBehavior), new PropertyMetadata(null));
+    }
+}


### PR DESCRIPTION
I made this behavior a while ago and I found it to be very useful. It’s triggers when a component becomes visible (including all parents). I use it for instance to set focus on button or lists that becomes visible when data has been downloaded, which happens a lot in my applications :) It can also be used instead of EventTriggerBehavior to set focus when a page has been downloaded.

Not sure if this should be a part of Template10, but I make a pull request and let you decide :)
