### PR TITLE
Fix NullReferenceException in HamburgerMenu when space/enter key is hold

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -400,9 +400,9 @@ namespace Template10.Controls
                 pageParam = NavigationService.CurrentPageParam;
             }
             else if (pageParam.ToString().StartsWith("{"))
+            {
+                try
                 {
-                    try
-                    {
                     pageParam = NavigationService.FrameFacade.SerializationService.Deserialize(pageParam.ToString());
                 }
                 catch { }

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -252,7 +252,11 @@ namespace Template10.Controls
                     if (currentItem != null)
                     {
                         var info = new InfoElement(currentItem);
-                        NavCommand.Execute(info.HamburgerButtonInfo);
+                        var hamburgerButtonInfo = info.HamburgerButtonInfo;
+                        if (hamburgerButtonInfo != null)
+                        {
+                            NavCommand.Execute(hamburgerButtonInfo);
+                        }
                     }
 
                     break;
@@ -396,9 +400,9 @@ namespace Template10.Controls
                 pageParam = NavigationService.CurrentPageParam;
             }
             else if (pageParam.ToString().StartsWith("{"))
-            {
-                try
                 {
+                    try
+                    {
                     pageParam = NavigationService.FrameFacade.SerializationService.Deserialize(pageParam.ToString());
                 }
                 catch { }


### PR DESCRIPTION
If space or enter key is pressed and hold on HamburgerMenu while the hamburgerbutton has the focus, NavCommand.Execute() is called with "null" parameter, causing an exception in the method. This PR fixes this.
