### PR TITLE
Set HamburgerButton.Margen in FullScreen to move button away

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -593,10 +593,12 @@ namespace Template10.Controls
                 {
                     Margin = new Thickness(-square.Width, 0, 0, 0);
                 }
+                HamburgerButton.Margin = new Thickness(-HamburgerButton.ActualWidth, 0, 0, 0);
             }
             else
             {
                 Margin = new Thickness(0);
+                HamburgerButton.Margin = new Thickness(0);
             }
 
             // hiding these elements prevents flicker


### PR DESCRIPTION
Update HamburgerButton.Margen in FullScreen mode because HamburgerButton with Opacity=0 interfers with buttons in title area
