### PR TITLE
Update ChangeTypeConverter.cs

### DIFF
--- a/Template10 (Library)/Converters/ChangeTypeConverter.cs
+++ b/Template10 (Library)/Converters/ChangeTypeConverter.cs
@@ -25,8 +25,8 @@ namespace Template10.Converters
             if (value == null && targetType.GetTypeInfo().IsValueType)
                 return Activator.CreateInstance(targetType);
 
-            if (targetType == typeof(object))
-                return (object)value;
+            if (targetType.IsInstanceOfType(value))
+                return value;
 
             return System.Convert.ChangeType(value, targetType);
         }


### PR DESCRIPTION
Updated to check for IsInstanceOfType instead of object so objects from derived classes don't throw an exception when System.Convert.ChangeType is called (e.g. when IConvertible is not implemented).

Why:
I tried out the converter today and ran into an error immediately. My app uses a ListView with a DataTemplateSelector. Depending on the type of the objects in the bound collection (they inherit the same interface) a different ListViewItem is generated. The convert method was causing the trouble as it tried to convert the actual instances to the interface type.
