### PR TITLE
Adds TryDeserialize() Json method that absorbs InvalidCastException.

### DIFF
--- a/Template10 (Library)/Services/SerializationService/ISerializationService.cs
+++ b/Template10 (Library)/Services/SerializationService/ISerializationService.cs
@@ -18,5 +18,10 @@ namespace Template10.Services.SerializationService
         /// Deserializes the parameter.
         /// </summary>
         T Deserialize<T>(string parameter);
+
+        /// <summary>
+        /// Attempts to deserialize the parameter.
+        /// </summary>
+        bool TryDeserialize<T>(string parameter, out T result);
     }
 }

--- a/Template10 (Library)/Services/SerializationService/JsonSerializationService.cs
+++ b/Template10 (Library)/Services/SerializationService/JsonSerializationService.cs
@@ -94,6 +94,37 @@ namespace Template10.Services.SerializationService
             return default(T);
         }
 
+        /// <summary>
+        /// Attempts to deserialize the value by absorbing the InvalidCastException that may occur.
+        /// </summary>
+        /// <returns>
+        /// True if deserialization succeeded with non-null result, otherwise False.
+        /// </returns>
+        /// <remarks>
+        /// On success (or return True) deserialized result is copied to the 'out' variable.
+        /// On fail (or return False) default(T) is copied to the 'out' variable.
+        /// </remarks>
+        public bool TryDeserialize<T>(string value, out T result)
+        {
+            object r = this.Deserialize(value);
+            if (r == null)
+            {
+                result = default(T);
+                return false;
+            }
+
+            try
+            {
+                result = (T)r;
+                return true;
+            }
+            catch
+            {
+                result = default(T);
+                return false;
+            }
+        }
+
         #region Internal Container Class
 
         sealed class Container


### PR DESCRIPTION
@JerryNixon - not sure how popular this will be with developers but I find it useful and you decide.

There are situations where one needs to pass different Types of parameters to the same nav event handler -- say, **string** one time and **bool** another time -- in which case deserializing tends to be untidy as a result of different parameter Types (i.e., the need to catch InvalidCastException). One good example is navigation _Refresh(object parameter)_ which may use a different parameter Type from the normal navigation parameter Type. There are workarounds to deal with this but thought **TryDeserialize()** that absorbs the **InvalidCastException** is one convenient deserializing method to have around.
### USAGE EXAMPLE

```
string someString;
if(SerializationService.Json.TryDeserialize(OnNavigatedToEventArgs.Parameter?.ToString(), out someString))
{
    // do something with someString
}

bool IsSomeBool;
if(SerializationService.Json.TryDeserialize(OnNavigatedToEventArgs.Parameter?.ToString(), out IsSomeBool))
{
    // do something with IsSomeBool
}
```
