### PR TITLE
Solves PageHeader's incorrect vertical alignment on Build 14393 Platform

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -327,7 +327,9 @@ namespace Template10.Controls
         {
             e.NewValue.AfterRestoreSavedNavigation += (s, args) => HighlightCorrectButton(NavigationService.CurrentPageType, NavigationService.CurrentPageParam);
             e.NewValue.FrameFacade.Navigated += (s, args) => HighlightCorrectButton(args.PageType, args.Parameter);
-            ShellSplitView.Content = e.NewValue.Frame;
+            var frame = e.NewValue.Frame;
+            frame.VerticalContentAlignment = VerticalAlignment.Top;
+            ShellSplitView.Content = frame;
             UpdateFullScreenForSplashScreen(e);
         }
 


### PR DESCRIPTION
If you run your app built around T10, you'll no doubt notice some visual differences. This is not unexpected. I have noticed simple ones such as where VerticalAlignment="Top" is expected, but the platform renders as if VerticalAlignment="Stretch" in action with some MaxHeight setting.

I have also noticed  rather subtle ones with Visual States Management, whereby ContentControl only expands, but never shrinks back with rather annoying consequences if you want to do such things such as visual toggling of PageHeader title and AppBarButtons. This PR solves the former problem with PageHeader.

It sets the page container frame VerticalAlignment to Top (default is Stretch) and as such **breaks nothing at all** since we always want the PageHeader to be aligned with the Top anyway. VerticalAlignment Stretch can break depending on Grid Column width setting (of \* or Auto) and container MaxHeight and I suspect this is what's at play with Build 14393.

So far I observed the above problem on 4" 14393 Mobile Emulator. See my previous posting of this issue as #1178.
