### PR TITLE
Adds layout adjustment to correct PageHeader non-alignment with the top.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -264,7 +264,12 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <RelativePanel x:Name="RootGrid">
+    <!--
+    Margin definition was added to correct PageHeader not aligning with the top on AU Platform.
+    So far, it is not clear what is causing this (nor whom to attribute to between AU and T10!).
+    Top offset value <= -0.4 works and -1 picked as shown below.
+    -->
+    <RelativePanel x:Name="RootGrid" Margin="0,-1,0,0">
 
         <VisualStateManager.VisualStateGroups>
 


### PR DESCRIPTION
- Take No. 2 of PR #1199. See also related issue #1178.
- I tried to explain the issue in #1199 and this PR provides a simpler solution than #1199 -- just a Margin definition. Note that this problem, so far, shows up on 14393 4" Mobile Emulator but haven't tested on 4" device. I am not sure if it's limited to Mobile Emulator.
- As yet not certain what XAML changes in the AU Platform are responsible for such display issues (more PR to come) - if anyone has an explanation to share it would be appreciated.
- Use HamurgerMenu Template project with 4" 14393 Mobile Emulator to test this PR.
