### PR TITLE
Fixed extended splash image location

### DIFF
--- a/Templates (Project)/Hamburger/Views/Splash.xaml
+++ b/Templates (Project)/Hamburger/Views/Splash.xaml
@@ -15,11 +15,7 @@
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
             <Canvas.Background>
-                <ImageBrush ImageSource="ms-appx:///Assets/SplashScreen.png" Stretch="Uniform">
-                    <ImageBrush.Transform>
-                        <TranslateTransform Y="10" />
-                    </ImageBrush.Transform>
-                </ImageBrush>
+                <ImageBrush ImageSource="ms-appx:///Assets/SplashScreen.png" Stretch="Uniform" />
             </Canvas.Background>
             <Viewbox x:Name="splashImage">
                 <Image Source="ms-appx:///Assets/SplashScreen.png" ImageOpened="Image_Loaded" />


### PR DESCRIPTION
The image was rendering on the incorrect location on Windows 10 Mobile.
