### PR TITLE
Fixes duplicate Dictionary key entry Exception in BootStrapper.cs

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -539,11 +539,11 @@ namespace Template10.Common
             set
             {
                 DebugWrite($"CurrenstState changed to {value}");
-                CurrentStateHistory.Add(DateTime.Now, value);
+                CurrentStateHistory.Add($"{DateTime.Now.Ticks} - {value}", value);
                 _currentState = value;
             }
         }
-        Dictionary<DateTime, States> CurrentStateHistory = new Dictionary<DateTime, States>();
+        Dictionary<string, States> CurrentStateHistory = new Dictionary<string, States>();
 
         private async Task InitializeFrameAsync(IActivatedEventArgs e)
         {


### PR DESCRIPTION
### Issue

[CurrentStateHistory.Add(DateTime.Now, value);](https://github.com/Windows-XAML/Template10/blob/master/Template10%20%28Library%29/Common/BootStrapper.cs#L542) in _BootStrapper.cs_.

The above causes duplicate key entry Exception, and I noted states **BeforeInnit** and **AfterInit** as well as **AfterStart** and **Running** received the same key derived from **DateTime.Now**. I don't think my computer was that super-fast to handle life-cycle detection within a Tick (100ns); it is just DateTime.Now is lousy [where precision is sought] and cannot be relied upon, particularly as a Dictionary key. Although **DateTime** gives us a resolution of 100ns, it only gets updated every [60 to 100 times per sec](http://www.codeproject.com/Articles/17474/Timer-surprises-and-how-to-avoid-them) hence the problem.
### Resolution

Since we only need the value of **CurrentStateHistory** (**Key** is simply for uniqueness) we can change how a unique Key is derived.

`string key = $"{DateTime.Now.Ticks} - {value}";`

Even if desirable to get a Time value corresponding to a State, the **Tick** value can be easily extracted from the key string above but see no need for doing that.
