### PR TITLE
Allow NavToPageAction to Navigate even if Frame is not available.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ Templates (Project)/Blank/null
 /packages/Microsoft.VSSDK.BuildTools.14.1.24720
 
 *.zip
+/Template10 (Installer)/Template10.Installer/ProjectTemplates/Windows/Universal/Template10/Temp

--- a/Template10 (Library)/Behaviors/NavToPageAction.cs
+++ b/Template10 (Library)/Behaviors/NavToPageAction.cs
@@ -26,15 +26,7 @@ namespace Template10.Behaviors
             if (nav == null)
                 throw new NullReferenceException($"Cannot find NavigationService for {Frame.ToString()}.");
 
-            var metadataProvider = Application.Current as IXamlMetadataProvider;
-            if (metadataProvider == null)
-                return false;
-
-            var pagetype = metadataProvider.GetXamlType(Page as Type);
-            if (pagetype == null)
-                throw new NullReferenceException($"Cannot find TargetPage:{Page}");
-
-            nav.Navigate(pagetype as Type, Parameter, InfoOverride);
+            nav.Navigate(Page as Type, Parameter, InfoOverride);
             return null;
         }
 

--- a/Template10 (Library)/Converters/ValueWhenConverter.cs
+++ b/Template10 (Library)/Converters/ValueWhenConverter.cs
@@ -13,14 +13,24 @@ namespace Template10.Converters
                 Debugger.Break();
             try
             {
-                if (object.Equals(value,parameter ?? When))
-                    return Value;
-                return Otherwise;
+                if (value is String && String.IsNullOrEmpty((String)When))
+                {
+                    if (String.IsNullOrEmpty((String)value))
+                        return Value;
+                }
+                else
+                {
+                    if (object.Equals(value, parameter ?? When))
+                        return Value;
+                }
+
+                return Otherwise ?? value;
             }
             catch
             {
-                return Otherwise;
+                return Otherwise ?? value;
             }
+
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)


### PR DESCRIPTION
In one of my project I have extended the Hamburger menu in the Shell.xaml view by adding a sub menu level (Tapped Event). The Frame is not available in the Shell.xaml (null) and navigation using the NavToPageAction is impossible.

I have added the test on the Frame properties and if null I use the  WindowWrapper.Current().NavigationServices.FirstOrDefault() and I can still navigate.
