### PR TITLE
Implements conditional page navigation for view-model (e.g canceling navigation for unsaved data).

### DIFF
--- a/Template10 (Library)/Mvvm/ViewModelBase.cs
+++ b/Template10 (Library)/Mvvm/ViewModelBase.cs
@@ -34,7 +34,6 @@ namespace Template10.Mvvm
         [JsonIgnore]
         public virtual IStateItems SessionState { get; set; }
 
-        [JsonIgnore]
         public virtual Task<bool> PageCanNavigateAwayAsync ()
         {
             return Task.FromResult(true);

--- a/Template10 (Library)/Mvvm/ViewModelBase.cs
+++ b/Template10 (Library)/Mvvm/ViewModelBase.cs
@@ -33,5 +33,10 @@ namespace Template10.Mvvm
 
         [JsonIgnore]
         public virtual IStateItems SessionState { get; set; }
+
+        public virtual Task<bool> PageCanNavigateAway ()
+        {
+            return Task.FromResult(true);
+        }
     }
 }

--- a/Template10 (Library)/Mvvm/ViewModelBase.cs
+++ b/Template10 (Library)/Mvvm/ViewModelBase.cs
@@ -34,6 +34,7 @@ namespace Template10.Mvvm
         [JsonIgnore]
         public virtual IStateItems SessionState { get; set; }
 
+        [JsonIgnore]
         public virtual Task<bool> PageCanNavigateAwayAsync ()
         {
             return Task.FromResult(true);

--- a/Template10 (Library)/Mvvm/ViewModelBase.cs
+++ b/Template10 (Library)/Mvvm/ViewModelBase.cs
@@ -34,7 +34,7 @@ namespace Template10.Mvvm
         [JsonIgnore]
         public virtual IStateItems SessionState { get; set; }
 
-        public virtual Task<bool> PageCanNavigateAway ()
+        public virtual Task<bool> PageCanNavigateAwayAsync ()
         {
             return Task.FromResult(true);
         }

--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -305,7 +305,7 @@ namespace Template10.Services.NavigationService
             _navigatingEventHandlers.ForEach(x => x(this, args));
             await deferral.WaitForDeferralsAsync().ConfigureAwait(false);
             var pageNavigable = (Content as Page)?.DataContext as INavigable;
-            e.Cancel = args.Cancel || ((pageNavigable != null) && !await pageNavigable.PageCanNavigateAway());
+            e.Cancel = args.Cancel || ((pageNavigable != null) && !await pageNavigable.PageCanNavigateAwayAsync());
         }
     }
 

--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -304,7 +304,8 @@ namespace Template10.Services.NavigationService
             NavigationModeHint = NavigationMode.New;
             _navigatingEventHandlers.ForEach(x => x(this, args));
             await deferral.WaitForDeferralsAsync().ConfigureAwait(false);
-            e.Cancel = args.Cancel;
+            var pageNavigable = (Content as Page)?.DataContext as INavigable;
+            e.Cancel = args.Cancel || ((pageNavigable != null) && !await pageNavigable.PageCanNavigateAway());
         }
     }
 

--- a/Template10 (Library)/Services/NavigationService/INavigable.cs
+++ b/Template10 (Library)/Services/NavigationService/INavigable.cs
@@ -14,5 +14,6 @@ namespace Template10.Services.NavigationService
         INavigationService NavigationService { get; set; }
         IDispatcherWrapper Dispatcher { get; set; }
         IStateItems SessionState { get; set; }
+        Task<bool> PageCanNavigateAway();
     }
 }

--- a/Template10 (Library)/Services/NavigationService/INavigable.cs
+++ b/Template10 (Library)/Services/NavigationService/INavigable.cs
@@ -14,6 +14,6 @@ namespace Template10.Services.NavigationService
         INavigationService NavigationService { get; set; }
         IDispatcherWrapper Dispatcher { get; set; }
         IStateItems SessionState { get; set; }
-        Task<bool> PageCanNavigateAway();
+        Task<bool> PageCanNavigateAwayAsync();
     }
 }


### PR DESCRIPTION
### Background

Navigation cancellation in ViewModel is currently impossible as confirmed by @JerryNixon [here](https://github.com/Windows-XAML/Template10/issues/1149).

> Yeah, turns out when you introduce an await in NavingFrom() Cancel no longer works because the NavService is using events instead of rewriting the underlying nav pipeline, but we're going to fix that in the next version. 

Issue #1149 provides the relevant background as contributed by @bbougot, @aline-almeida, @Monsok and @elstringo. This issue is also [listed as a to-do item](https://github.com/Windows-XAML/Template10/issues/1221) for the forthcoming release 1.1.12.
### Solution

Perhaps a workaround?
- This PR adds a bool method **PageCanNavigateAwayAsync ()** to the **INavigable Interface** for the developer to _override_ and _return false_ when nav cancellation is desired.
- The default virtual implementation in **ViewModelBase** always returns true and, if not overridden, it's as if nothing has changed.
- The **FrameFacade** event  [FacadeNavigatingCancelEventHandler](https://github.com/Windows-XAML/Template10/blob/master/Template10%20%28Library%29/Services/NavigationService/FrameFacade.cs#L287) gets to see what the developer is returning via **PageCanNavigateAwayAsync ()** in ViewModel and accordingly updates its [e.Cancel](https://github.com/Windows-XAML/Template10/blob/master/Template10%20%28Library%29/Services/NavigationService/FrameFacade.cs#L307) flag. _Q.E.D._
### Usage Example

```
// ViewModel skeleton code to highlight the above

public class MyViewModel : ViewModelBase
{
    private bool PageHasDataToSave;            // set this field to true to cancel navigation

    ...

    public override async Task<bool> PageCanNavigateAwayAsync ()
    {
        return !PageHasDataToSave;
    }

        ...

    // OnNavigatingFromAsync is where most of the action happens. 
    // Assume PageHasDataToSave flag was set somewhere where data change took place.

    public override async Task OnNavigatingFromAsync(NavigatingEventArgs e)
    {
        await base.OnNavigatingFromAsync(e);
        if (PageHasDataToSave)
        {
            // Message.Show is just a helper method built around MessageDialog class [1], so just take the concept here...
            // Message.Show returns: true when OK button cliked; false when Cancel button clicked.
            bool OkToDiscard = await Message.Show(ResourceLoader.GetForViewIndependentUse().GetString("ConfirmDataChangeDiscard"), MessageDialogButton.OKCancel);
            if (!OkToDiscard)
            {
                e.Cancel = true;
                return;
            }

           // OK to discard, so negate the flag to let subsequent nav to proceed as normal.
            PageHasDataToSave = false; 
        }

        // If proceeded here, it means user has opted to discard unsaved data, so let's navigate ...
        // I wonder if the following lines could be simplified??

        if (e.NavigationMode == NavigationMode.Back)
        {
            if (BootStrapper.Current.NavigationService.CanGoBack) BootStrapper.Current.NavigationService.GoBack();
        }
        else if (e.NavigationMode == NavigationMode.Forward)
        {
            if (BootStrapper.Current.NavigationService.CanGoForward) BootStrapper.Current.NavigationService.GoForward();
        }
        else if (e.NavigationMode == NavigationMode.Refresh)
        {
            BootStrapper.Current.NavigationService.Refresh();
        }
        else if (e.NavigationMode == NavigationMode.New)
        {
            BootStrapper.Current.NavigationService.Navigate(e.TargetPageType, e.TargetPageParameter);
        }
    }
}
```

---

[[1](https://msdn.microsoft.com/library/windows/apps/br208674)]
