### PR TITLE
Fix HamburgerMenu header visibility

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -456,12 +456,13 @@
 
         <ContentControl x:Name="Header"
                         Height="48"
-                        HorizontalContentAlignment="Left"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
                         VerticalContentAlignment="Center"
                         Canvas.ZIndex="2"
                         Content="{Binding HeaderContent, ElementName=ThisPage}"
                         IsTabStop="False"
-                        RelativePanel.AlignRightWith="HeaderBackground"
+                        RelativePanel.AlignRightWithPanel="True"
                         RelativePanel.AlignTopWith="HamburgerButton"
                         RelativePanel.RightOf="HamburgerButton" />
 

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -607,6 +607,8 @@ namespace Template10.Controls
 
             // hiding these elements prevents flicker
             Header.Opacity = opacity;
+            Header.Visibility = opacity == 1 ? Visibility.Visible : Visibility.Collapsed;
+
             HamburgerButton.Opacity = opacity;
             HamburgerBackground.Opacity = opacity;
             PaneContent.Opacity = opacity;


### PR DESCRIPTION
When FullScreen mode is active, the Header control must also be set to Visible=Collapsed because even it has opacity of 0, it still interacts with controls that might be behind the invisible header.
