### PR TITLE
Changes literal string property names in DependencyProperty.Register() to nameof(PropertyName).

### DIFF
--- a/Samples/BehaviorSample/Views/MainPage.xaml.cs
+++ b/Samples/BehaviorSample/Views/MainPage.xaml.cs
@@ -16,7 +16,7 @@ namespace Template10.Samples.BehaviorsSample.Views
             set { SetValue(ThrottledEventCountProperty, value); }
         }
 
-        public static readonly DependencyProperty ThrottledEventCountProperty = DependencyProperty.Register("ThrottledEventCount", typeof (int), typeof (MainPage), new PropertyMetadata(0));
+        public static readonly DependencyProperty ThrottledEventCountProperty = DependencyProperty.Register(nameof(ThrottledEventCount), typeof (int), typeof (MainPage), new PropertyMetadata(0));
 
         public void IncreaseThrottledEventCount()
         {

--- a/Samples/DyanmicFontSize/Controls/RichTextColumns.cs
+++ b/Samples/DyanmicFontSize/Controls/RichTextColumns.cs
@@ -39,14 +39,14 @@ namespace Template10.Samples.DynamicFontSizeSample.Controls
         /// Identifies the <see cref="RichTextContent"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty RichTextContentProperty =
-            DependencyProperty.Register("RichTextContent", typeof(RichTextBlock),
+            DependencyProperty.Register(nameof(RichTextContent), typeof(RichTextBlock),
             typeof(RichTextColumns), new PropertyMetadata(null, ResetOverflowLayout));
 
         /// <summary>
         /// Identifies the <see cref="ColumnTemplate"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty ColumnTemplateProperty =
-            DependencyProperty.Register("ColumnTemplate", typeof(DataTemplate),
+            DependencyProperty.Register(nameof(ColumnTemplate), typeof(DataTemplate),
             typeof(RichTextColumns), new PropertyMetadata(null, ResetOverflowLayout));
 
         /// <summary>

--- a/Template10 (Library)/Behaviors/ThrottledEventTriggerBehavior.cs
+++ b/Template10 (Library)/Behaviors/ThrottledEventTriggerBehavior.cs
@@ -36,7 +36,7 @@ namespace Template10.Behaviors
         /// <summary>
         /// Throttle period (in milliseconds)
         /// </summary>
-        public static readonly DependencyProperty ThrottleProperty = DependencyProperty.Register("Throttle", typeof (int), typeof (ThrottledEventTriggerBehavior), new PropertyMetadata(1000, ThrottlePropertyChangedCallback));
+        public static readonly DependencyProperty ThrottleProperty = DependencyProperty.Register(nameof(Throttle), typeof (int), typeof (ThrottledEventTriggerBehavior), new PropertyMetadata(1000, ThrottlePropertyChangedCallback));
 
         private static void ThrottlePropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -56,7 +56,7 @@ namespace Template10.Behaviors
         /// <summary>
         /// Reset throttle timer after each event.
         /// </summary>
-        public static readonly DependencyProperty ResetTimerProperty = DependencyProperty.Register("ResetTimer", typeof (bool), typeof (ThrottledEventTriggerBehavior), new PropertyMetadata(false, ResetTimerPropertyChangedCallback));
+        public static readonly DependencyProperty ResetTimerProperty = DependencyProperty.Register(nameof(ResetTimer), typeof (bool), typeof (ThrottledEventTriggerBehavior), new PropertyMetadata(false, ResetTimerPropertyChangedCallback));
 
         private static void ResetTimerPropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/Template10 (Library)/Common/EventThrottleHelper.cs
+++ b/Template10 (Library)/Common/EventThrottleHelper.cs
@@ -36,13 +36,13 @@ namespace Template10.Common
         /// <summary>
         /// Reset throttle timer after each event.
         /// </summary>
-        public static readonly DependencyProperty ResetTimerProperty = DependencyProperty.Register("ResetTimer", typeof (bool), typeof (EventThrottleHelper), new PropertyMetadata(false));
+        public static readonly DependencyProperty ResetTimerProperty = DependencyProperty.Register(nameof(ResetTimer), typeof (bool), typeof (EventThrottleHelper), new PropertyMetadata(false));
 
 
         /// <summary>
         /// Throttle time in milliseconds.
         /// </summary>
-        public static readonly DependencyProperty ThrottleProperty = DependencyProperty.Register("Throttle", typeof (int), typeof (EventThrottleHelper), new PropertyMetadata(1000));
+        public static readonly DependencyProperty ThrottleProperty = DependencyProperty.Register(nameof(Throttle), typeof (int), typeof (EventThrottleHelper), new PropertyMetadata(1000));
 
         private IDispatcherWrapper dispatcherObj;
 

--- a/Template10 (Library)/Controls/PageHeader.cs
+++ b/Template10 (Library)/Controls/PageHeader.cs
@@ -171,7 +171,7 @@ namespace Template10.Controls
             set { SetValue(TextProperty, value); }
         }
         public static readonly DependencyProperty TextProperty =
-            DependencyProperty.Register("Text", typeof(string), typeof(PageHeader), new PropertyMetadata(string.Empty, (d, e) =>
+            DependencyProperty.Register(nameof(Text), typeof(string), typeof(PageHeader), new PropertyMetadata(string.Empty, (d, e) =>
             {
                 (d as PageHeader).Content = e.NewValue;
             }));


### PR DESCRIPTION
The title says it all.
