### PR TITLE
The synchronous implementation of Dispatch should not be async

### DIFF
--- a/Template10 (Library)/Common/DispatcherWrapper.cs
+++ b/Template10 (Library)/Common/DispatcherWrapper.cs
@@ -33,8 +33,8 @@ namespace Template10.Common
         public async Task DispatchAsync(Action action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-                await Task.Delay(delayms).ConfigureAwait(false);
 
+                await Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess);
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 action();
@@ -61,8 +61,8 @@ namespace Template10.Common
         public async Task DispatchAsync(Func<Task> func, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-                await Task.Delay(delayms).ConfigureAwait(false);
 
+                await Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess);
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 await func().ConfigureAwait(false);
@@ -89,8 +89,8 @@ namespace Template10.Common
         public async Task<T> DispatchAsync<T>(Func<T> func, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-                await Task.Delay(delayms).ConfigureAwait(false);
 
+                await Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess);
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 return func();
@@ -116,8 +116,8 @@ namespace Template10.Common
         public void Dispatch(Action action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-                await Task.Delay(delayms).ConfigureAwait(false);
 
+                Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess).GetAwaiter().GetResult();
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 action();
@@ -131,8 +131,8 @@ namespace Template10.Common
         public T Dispatch<T>(Func<T> action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-                Task.Delay(delayms).ConfigureAwait(false).GetAwaiter().GetResult();
 
+                Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess).GetAwaiter().GetResult();
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 return action();
@@ -217,10 +217,10 @@ namespace Template10.Common
             return await tcs.Task.ConfigureAwait(false);
         }
 
-        public async void DispatchIdle(Action action, int delayms = 0)
+        public void DispatchIdle(Action action, int delayms = 0)
         {
             if (delayms > 0)
-                await Task.Delay(delayms).ConfigureAwait(false);
+                Task.Delay(delayms).ConfigureAwait(false).GetAwaiter().GetResult();
 
             dispatcher.RunIdleAsync(args => action()).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
         }

--- a/Template10 (Library)/Common/DispatcherWrapper.cs
+++ b/Template10 (Library)/Common/DispatcherWrapper.cs
@@ -113,7 +113,7 @@ namespace Template10.Common
             }
         }
 
-        public async void Dispatch(Action action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        public void Dispatch(Action action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
                 await Task.Delay(delayms).ConfigureAwait(false);

--- a/Template10 (Library)/Common/DispatcherWrapper.cs
+++ b/Template10 (Library)/Common/DispatcherWrapper.cs
@@ -33,8 +33,8 @@ namespace Template10.Common
         public async Task DispatchAsync(Action action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-
                 await Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess);
+
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 action();
@@ -61,8 +61,8 @@ namespace Template10.Common
         public async Task DispatchAsync(Func<Task> func, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-
                 await Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess);
+
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 await func().ConfigureAwait(false);
@@ -89,8 +89,8 @@ namespace Template10.Common
         public async Task<T> DispatchAsync<T>(Func<T> func, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-
                 await Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess);
+
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 return func();
@@ -116,8 +116,8 @@ namespace Template10.Common
         public void Dispatch(Action action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-
                 Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess).GetAwaiter().GetResult();
+
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 action();
@@ -131,8 +131,8 @@ namespace Template10.Common
         public T Dispatch<T>(Func<T> action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (delayms > 0)
-
                 Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess).GetAwaiter().GetResult();
+
             if (dispatcher.HasThreadAccess && priority == CoreDispatcherPriority.Normal)
             {
                 return action();

--- a/Template10 (Library)/Common/IDispatcherWrapper.cs
+++ b/Template10 (Library)/Common/IDispatcherWrapper.cs
@@ -8,11 +8,13 @@ namespace Template10.Common
     public interface IDispatcherWrapper
     {
         void Dispatch(Action action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal);
+        T Dispatch<T>(Func<T> action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal);
         Task DispatchAsync(Func<Task> func, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal);
         Task DispatchAsync(Action action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal);
         Task<T> DispatchAsync<T>(Func<T> func, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal);
 
         void DispatchIdle(Action action, int delayms = 0);
+        T DispatchIdle<T>(Func<T> action, int delayms = 0) where T : class;
         Task DispatchIdleAsync(Func<Task> func, int delayms = 0);
         Task DispatchIdleAsync(Action action, int delayms = 0);
         Task<T> DispatchIdleAsync<T>(Func<T> func, int delayms = 0);


### PR DESCRIPTION
The synchronous implementation of Dispatch should not be async because when then method is declared as `async void`, Dispatch will return before the method is executed, which might cause strange errors. It is also useless here because Dispatch should switch into the UI thread...

Also fixed issue that is caused by `Task.Delay(delayms).ConfigureAwait(false);` before dispatcher.HasThreadAccess is checked. ConfigureAwait(false) might cause a thread change if the Dispatch methods are called from UI thread and cause an unneccessary switch out and back into the UI thread. So, we should use await `Task.Delay(delayms).ConfigureAwait(dispatcher.HasThreadAccess)` to make sure that we stay in the UI thread when we come from the UI thread.

**Please review for side effects.**
