### PR TITLE
Changed URLs to reflect renamed pages or new pages

### DIFF
--- a/Samples/Converters/readme.md
+++ b/Samples/Converters/readme.md
@@ -2,7 +2,7 @@
 
 This sample demonstrates the use of various Converters included in the Template10 library. There is a single **View** (MainPage.xaml) and a single **ViewModel** (MainPageViewModel.cs).
 
-To learn more about Converters you can check the [wiki documentation](https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-Converters).
+To learn more about Converters you can check the [wiki documentation](https://github.com/Windows-XAML/Template10/wiki/Converters).
 
 ![Converters Demo](img/sampleapp.png)
 

--- a/Samples/PageHeaderSample/Mvvm/ViewModelBase.cs
+++ b/Samples/PageHeaderSample/Mvvm/ViewModelBase.cs
@@ -1,6 +1,6 @@
 namespace Template10.Samples.PageHeaderSample.Mvvm
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-MVVM
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/MVVM
     public abstract class ViewModelBase : Template10.Mvvm.ViewModelBase
 	{
 		// the only thing that matters here is Template10.Services.NavigationService.INavagable

--- a/Samples/Search/Views/Shell.xaml.cs
+++ b/Samples/Search/Views/Shell.xaml.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Template10.Samples.SearchSample.Views
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-SplitView
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Controls#splitview
     public sealed partial class Shell : Page
     {
         public static Shell Instance { get; set; }

--- a/Samples/Voice and Ink to TextBox/Mvvm/ViewModelBase.cs
+++ b/Samples/Voice and Ink to TextBox/Mvvm/ViewModelBase.cs
@@ -1,6 +1,6 @@
 namespace Template10.Samples.VoiceAndInkSample.Mvvm
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-MVVM
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/MVVM
     public abstract class ViewModelBase : Template10.Mvvm.ViewModelBase
     {
         // the only thing that matters here is Template10.Services.NavigationService.INavagable

--- a/Samples/Voice and Ink to TextBox/Services/SettingsServices/SettingsService.cs
+++ b/Samples/Voice and Ink to TextBox/Services/SettingsServices/SettingsService.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml;
 
 namespace Template10.Samples.VoiceAndInkSample.Services.SettingsServices
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-SettingsService
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Services#settingsservice
     public partial class SettingsService : ISettingsService
     {
         public static SettingsService Instance { get; }

--- a/Samples/Voice and Ink to TextBox/Views/Shell.xaml.cs
+++ b/Samples/Voice and Ink to TextBox/Views/Shell.xaml.cs
@@ -7,7 +7,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Template10.Samples.VoiceAndInkSample.Views
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-SplitView
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Controls#splitview
     public sealed partial class Shell : Page, INotifyPropertyChanged
     {
         public static Shell Instance { get; set; }

--- a/Samples/Voice and Ink to TextBox/Views/Splash.xaml.cs
+++ b/Samples/Voice and Ink to TextBox/Views/Splash.xaml.cs
@@ -5,7 +5,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Template10.Samples.VoiceAndInkSample.Views
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-SplashScreen
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/SplashScreen
     public sealed partial class Splash : UserControl
     {
         public Splash(SplashScreen splashScreen)

--- a/Template10 (Library)/Behaviors/ConditionalAction.cs
+++ b/Template10 (Library)/Behaviors/ConditionalAction.cs
@@ -5,7 +5,7 @@ using Windows.UI.Xaml.Markup;
 
 namespace Template10.Behaviors
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-XamlBehaviors
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Behaviors-and-Actions
     [ContentProperty(Name = nameof(Actions))]
     public sealed class ConditionalAction : DependencyObject, IAction
     {

--- a/Template10 (Library)/Behaviors/EllipsisBehavior.cs
+++ b/Template10 (Library)/Behaviors/EllipsisBehavior.cs
@@ -10,7 +10,7 @@ using Template10.Controls;
 
 namespace Template10.Behaviors
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-XamlBehaviors
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Behaviors-and-Actions
     [TypeConstraint(typeof(CommandBar))]
     public class EllipsisBehavior : DependencyObject, IBehavior
     {

--- a/Template10 (Library)/Behaviors/NavButtonBehavior.cs
+++ b/Template10 (Library)/Behaviors/NavButtonBehavior.cs
@@ -13,7 +13,7 @@ using Template10.Common;
 
 namespace Template10.Behaviors
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-XamlBehaviors
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Behaviors-and-Actions
     [Microsoft.Xaml.Interactivity.TypeConstraint(typeof(Button))]
     public class NavButtonBehavior : DependencyObject, IBehavior
     {

--- a/Template10 (Library)/Behaviors/TextBoxEnterKeyBehavior.cs
+++ b/Template10 (Library)/Behaviors/TextBoxEnterKeyBehavior.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Markup;
 
 namespace Template10.Behaviors
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-XamlBehaviors
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Behaviors-and-Actions
     [ContentProperty(Name = nameof(Actions))]
     [TypeConstraint(typeof(TextBox))]
     [Obsolete("Use KeyBehavior instead.")]

--- a/Template10 (Library)/Behaviors/TimeoutAction.cs
+++ b/Template10 (Library)/Behaviors/TimeoutAction.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml.Markup;
 
 namespace Template10.Behaviors
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-XamlBehaviors
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Behaviors-and-Actions
     [ContentProperty(Name = nameof(Actions))]
     public sealed class TimeoutAction : DependencyObject, IAction
     {

--- a/Template10 (Library)/Common/DispatcherWrapper.cs
+++ b/Template10 (Library)/Common/DispatcherWrapper.cs
@@ -8,7 +8,7 @@ using Windows.UI.Core;
 
 namespace Template10.Common
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-DispatcherWrapper
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/DispatcherWrapper
     public class DispatcherWrapper : IDispatcherWrapper
     {
         #region Debug

--- a/Template10 (Library)/Common/WindowWrapper.cs
+++ b/Template10 (Library)/Common/WindowWrapper.cs
@@ -11,7 +11,7 @@ using Windows.UI.Xaml;
 
 namespace Template10.Common
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-WindowWrapper
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/WindowWrapper
     public class WindowWrapper
     {
         #region Debug

--- a/Template10 (Library)/Converters/ChangeTypeConverter.cs
+++ b/Template10 (Library)/Converters/ChangeTypeConverter.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace Template10.Converters
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-Converters
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Converters
     public class ChangeTypeConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)

--- a/Template10 (Library)/Converters/DateTimeOffsetConverter.cs
+++ b/Template10 (Library)/Converters/DateTimeOffsetConverter.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml.Data;
 
 namespace Template10.Converters
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-Converters
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Converters
     public class DateTimeOffsetConverter : IValueConverter
     {
 

--- a/Template10 (Library)/Converters/ValueWhenConverter.cs
+++ b/Template10 (Library)/Converters/ValueWhenConverter.cs
@@ -4,7 +4,7 @@ using Windows.UI.Xaml.Data;
 
 namespace Template10.Converters
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-Converters
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Converters
     public class ValueWhenConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)

--- a/Template10 (Library)/Mvvm/BindableBase.cs
+++ b/Template10 (Library)/Mvvm/BindableBase.cs
@@ -8,7 +8,7 @@ using Template10.Utils;
 
 namespace Template10.Mvvm
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-MVVM
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/MVVM
     public abstract class BindableBase : IBindable
     {
         public event PropertyChangedEventHandler PropertyChanged;

--- a/Template10 (Library)/Mvvm/DelegateCommand.cs
+++ b/Template10 (Library)/Mvvm/DelegateCommand.cs
@@ -5,7 +5,7 @@ namespace Template10.Mvvm
     // http://codepaste.net/jgxazh
     using System.Diagnostics;
 
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-MVVM
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/MVVM
     public class DelegateCommand : IChangedCommand
     {
         private readonly Action _execute;
@@ -41,7 +41,7 @@ namespace Template10.Mvvm
         }
     }
 
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-MVVM
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/MVVM
     public class DelegateCommand<T> : IChangedCommand
     {
         private readonly Action<T> _execute;

--- a/Template10 (Library)/Mvvm/ViewModelBase.cs
+++ b/Template10 (Library)/Mvvm/ViewModelBase.cs
@@ -7,7 +7,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Template10.Mvvm
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-MVVM
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/MVVM
     public abstract class ViewModelBase : BindableBase, INavigable
     {
         public virtual Task OnNavigatedToAsync(object parameter, NavigationMode mode, IDictionary<string, object> state)

--- a/Template10 (Library)/Services/KeyboardService/KeyboardEventArgs.cs
+++ b/Template10 (Library)/Services/KeyboardService/KeyboardEventArgs.cs
@@ -8,7 +8,7 @@ using Windows.UI.Core;
 
 namespace Template10.Services.KeyboardService
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-KeyboardService
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Services#keyboardservice
     public class KeyboardEventArgs : EventArgs
     {
         public bool Handled { get; set; } = false;  

--- a/Template10 (Library)/Services/KeyboardService/KeyboardHelper.cs
+++ b/Template10 (Library)/Services/KeyboardService/KeyboardHelper.cs
@@ -9,7 +9,7 @@ using Windows.UI.Xaml;
 
 namespace Template10.Services.KeyboardService
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-KeyboardService
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Services#keyboardservice
     public class KeyboardHelper
     {
         CoreWindow win = Window.Current.CoreWindow;

--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 
 namespace Template10.Services.NavigationService
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Navigation-Service
     public class FrameFacade
     {
         #region Debug

--- a/Template10 (Library)/Services/NavigationService/INavigable.cs
+++ b/Template10 (Library)/Services/NavigationService/INavigable.cs
@@ -5,7 +5,7 @@ using Template10.Common;
 
 namespace Template10.Services.NavigationService
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Navigation-Service
     public interface INavigable
     {
         Task OnNavigatedToAsync(object parameter, NavigationMode mode, IDictionary<string, object> state);

--- a/Template10 (Library)/Services/NavigationService/NavigatedEventArgs.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigatedEventArgs.cs
@@ -4,7 +4,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Template10.Services.NavigationService
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Navigation-Service
     public class NavigatedEventArgs : EventArgs
     {
         public NavigatedEventArgs() { }

--- a/Template10 (Library)/Services/NavigationService/NavigatingEventArgs.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigatingEventArgs.cs
@@ -5,7 +5,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Template10.Services.NavigationService
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Navigation-Service
     public class NavigatingEventArgs : NavigatedEventArgs
     {
         DeferralManager Manager;

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -17,7 +17,7 @@ using Template10.Utils;
 
 namespace Template10.Services.NavigationService
 {
-    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-NavigationService
+    // DOCS: https://github.com/Windows-XAML/Template10/wiki/Navigation-Service
     public partial class NavigationService : INavigationService
     {
         private readonly IViewService viewService = new ViewService.ViewService();

--- a/Template10 (Library)/Services/SettingsService/SettingsService.cs
+++ b/Template10 (Library)/Services/SettingsService/SettingsService.cs
@@ -8,7 +8,7 @@ using Windows.Storage;
 
 namespace Template10.Services.SettingsService
 {
-    // https://github.com/Windows-XAML/Template10/wiki/Docs-%7C-SettingsService
+    // https://github.com/Windows-XAML/Template10/wiki/Services#settingsservice
     public class SettingsService : ISettingsService
     {
         private static ISettingsService _local;

--- a/Templates (Project)/Blank/Help.htm
+++ b/Templates (Project)/Blank/Help.htm
@@ -5,6 +5,6 @@
     <title>Template 10</title>
 </head>
 <body style="margin: 0; padding: 0;">
-    <meta http-equiv="refresh" content="2;url=https://github.com/Windows-XAML/Template10/wiki/Welcome-%7C-Blank-Template"> 
+    <meta http-equiv="refresh" content="2;url=https://github.com/Windows-XAML/Template10/wiki/Blank-Template"> 
 </body>
 </html>


### PR DESCRIPTION
Following the renaming of pages to remove %7C from the filenames, and the addition of new pages into the wiki, I've gone through all of the URLs referenced in the source code to make sure they are correct.

There are a couple of references to non-existent pages (Dispatcher Wrapper and Window Wrapper) but I've removed the %7C so that at least the filenames will be Windows-safe.
