### PR TITLE
Removed the post build events

### DIFF
--- a/Template10 (Library)/Template10 (Library).csproj
+++ b/Template10 (Library)/Template10 (Library).csproj
@@ -295,8 +295,8 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>call "$(ProjectDir)\Nuget\Build.cmd" "$(TargetDir)" "$(TargetName)" "$(ProjectDir)"
-call "$(SolutionDir)\Template10 (Installer)\InstallSnippets.cmd"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Removed the post build events from the Library projects to make it easier to leverage Template10 as submodule