### PR TITLE
Fix super strange exception in DebugWrite when nameof(Resuming) is used

### DIFF
--- a/Template10 (Library)/Common/BootStrapper.cs
+++ b/Template10 (Library)/Common/BootStrapper.cs
@@ -685,7 +685,7 @@ namespace Template10.Common
 
         private async void CallResuming(object sender, object e)
         {
-            DebugWrite(caller: nameof(Resuming));
+            DebugWrite();
 
             var args = OriginalActivatedArgs as LaunchActivatedEventArgs;
             if (args?.PrelaunchActivated ?? true)


### PR DESCRIPTION
This should fix https://github.com/Windows-XAML/Template10/issues/1260