### PR TITLE
HamburgerMenu - HighLightCorrectButton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ Templates (Project)/Blank/null
 /packages/Microsoft.VSSDK.BuildTools.14.1.24720
 
 *.zip
+/Template10 (Installer)/Template10.Installer/ProjectTemplates/Windows/Universal/Template10/Temp

--- a/Template10 (Library)/Behaviors/NavToPageAction.cs
+++ b/Template10 (Library)/Behaviors/NavToPageAction.cs
@@ -26,15 +26,7 @@ namespace Template10.Behaviors
             if (nav == null)
                 throw new NullReferenceException($"Cannot find NavigationService for {Frame.ToString()}.");
 
-            var metadataProvider = Application.Current as IXamlMetadataProvider;
-            if (metadataProvider == null)
-                return false;
-
-            var pagetype = metadataProvider.GetXamlType(Page as Type);
-            if (pagetype == null)
-                throw new NullReferenceException($"Cannot find TargetPage:{Page}");
-
-            nav.Navigate(pagetype as Type, Parameter, InfoOverride);
+            nav.Navigate(Page as Type, Parameter, InfoOverride);
             return null;
         }
 

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -411,7 +411,8 @@ namespace Template10.Controls
 
             // add parameter match
             buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
-            var button = buttons.Select(x => x.HamburgerButtonInfo).FirstOrDefault();
+            var button = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
+                                .Select(x => x.HamburgerButtonInfo).FirstOrDefault();
             Selected = button;
         }
 

--- a/Template10 (Library)/Converters/ValueWhenConverter.cs
+++ b/Template10 (Library)/Converters/ValueWhenConverter.cs
@@ -13,14 +13,24 @@ namespace Template10.Converters
                 Debugger.Break();
             try
             {
-                if (object.Equals(value,parameter ?? When))
-                    return Value;
-                return Otherwise;
+                if (value is String && String.IsNullOrEmpty((String)When))
+                {
+                    if (String.IsNullOrEmpty((String)value))
+                        return Value;
+                }
+                else
+                {
+                    if (object.Equals(value, parameter ?? When))
+                        return Value;
+                }
+
+                return Otherwise ?? value;
             }
             catch
             {
-                return Otherwise;
+                return Otherwise ?? value;
             }
+
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)


### PR DESCRIPTION
I have created a new one based on the latest master branch.

In the HamburgerMenu when a navigation starts, a search is started to find if a button exists to high light it.

The search criteria is first based on the type of the page and after on the PageParameter.
The select is based on 2 criterias: null or PageParameter equal to pageParam.

The error consists in the fact that if 2 buttons exist (one null and one with a parameter) the null is taken.

Introducing a OrderByDescending will force to select first the button matching the pageParam critieria.

            // add parameter match
            buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
            var button = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
                                .Select(x => x.HamburgerButtonInfo).FirstOrDefault();
            Selected = button;