### PR TITLE
HamburgerMenu FullScreen mode Tabstop/Enabled fix for Ham'Buttons

### DIFF
--- a/Template10 (Library)/Controls/HamburgerButtonInfo.cs
+++ b/Template10 (Library)/Controls/HamburgerButtonInfo.cs
@@ -157,7 +157,8 @@ namespace Template10.Controls
         }
         public static readonly DependencyProperty IsEnabledProperty =
             DependencyProperty.Register(nameof(IsEnabled), typeof(bool),
-                typeof(HamburgerButtonInfo), new PropertyMetadata(true));
+                typeof(HamburgerButtonInfo), new PropertyMetadata(true,
+                    (sender, args) => ((HamburgerButtonInfo) sender).UpdateInternalBindingValues()));
 
         public bool? IsChecked
         {
@@ -167,6 +168,16 @@ namespace Template10.Controls
         public static readonly DependencyProperty IsCheckedProperty =
             DependencyProperty.Register(nameof(IsChecked), typeof(object),
                 typeof(HamburgerButtonInfo), new PropertyMetadata(false));
+
+        public bool IsTabStop
+        {
+            get { return (bool)GetValue(IsTabStopProperty); }
+            set { SetValue(IsTabStopProperty, value); }
+        }
+        public static readonly DependencyProperty IsTabStopProperty =
+            DependencyProperty.Register(nameof(IsTabStop), typeof(object),
+                typeof(HamburgerButtonInfo), new PropertyMetadata(true,
+                    (sender, args) => ((HamburgerButtonInfo)sender).UpdateInternalBindingValues()));
 
         public UIElement Content
         {
@@ -188,36 +199,99 @@ namespace Template10.Controls
 
         public override string ToString() => string.Format($"IsChecked: {IsChecked} PageType: {PageType}, Parameter: {PageParameter}");
 
+        #region Internal binding properties
+
+        private void UpdateInternalBindingValues()
+        {
+            bool isFullScreen = this.IsFullScreen;
+            bool isEnabled = !isFullScreen && this.IsEnabled;
+            bool isTabStop = isEnabled && this.IsTabStop;
+
+            this.IsEnabled_InternalBinding = isEnabled;
+            this.IsTabStop_InternalBinding = isTabStop;
+        }
+
+        internal bool IsFullScreen
+        {
+            get { return (bool)this.GetValue(IsFullScreenProperty); }
+            set { this.SetValue(IsFullScreenProperty, value); }
+        }
+        internal static readonly DependencyProperty IsFullScreenProperty =
+            DependencyProperty.Register(nameof(IsFullScreenProperty), typeof(object),
+                typeof(HamburgerButtonInfo), new PropertyMetadata(false,
+                    (sender, args) => ((HamburgerButtonInfo)sender).UpdateInternalBindingValues()));
+
+        internal bool IsEnabled_InternalBinding
+        {
+            get { return (bool)this.GetValue(IsEnabled_InternalBindingProperty); }
+            set { this.SetValue(IsEnabled_InternalBindingProperty, value); }
+        }
+
+        internal static readonly DependencyProperty IsEnabled_InternalBindingProperty =
+            DependencyProperty.Register(nameof(IsEnabled_InternalBinding), typeof(object),
+                typeof(HamburgerButtonInfo), new PropertyMetadata(true));
+
+        internal bool IsTabStop_InternalBinding
+        {
+            get { return (bool)this.GetValue(IsTabStop_InternalBindingProperty); }
+            set { this.SetValue(IsTabStop_InternalBindingProperty, value); }
+        }
+        internal static readonly DependencyProperty IsTabStop_InternalBindingProperty =
+            DependencyProperty.Register(nameof(IsTabStop_InternalBinding), typeof(object),
+                typeof(HamburgerButtonInfo), new PropertyMetadata(true));
+
+        #endregion
+
         #region Events
 
         public event RoutedEventHandler Selected;
-        internal void RaiseSelected() => Selected?.Invoke(this, new RoutedEventArgs());
+        internal void RaiseSelected()
+        {
+            if (!IsFullScreen)
+                this.Selected?.Invoke(this, new RoutedEventArgs());
+        }
 
         public event RoutedEventHandler Unselected;
-        internal void RaiseUnselected() => Unselected?.Invoke(this, new RoutedEventArgs());
+        internal void RaiseUnselected()
+        {
+            if (!IsFullScreen)
+                this.Unselected?.Invoke(this, new RoutedEventArgs());
+        }
 
         public event RoutedEventHandler Checked;
         internal void RaiseChecked(RoutedEventArgs args)
         {
-            if (ButtonType == ButtonTypes.Toggle)
+            if ((ButtonType == ButtonTypes.Toggle) && !IsFullScreen)
                 Checked?.Invoke(this, args);
         }
 
         public event RoutedEventHandler Unchecked;
         internal void RaiseUnchecked(RoutedEventArgs args)
         {
-            if (ButtonType == ButtonTypes.Toggle)
+            if ((ButtonType == ButtonTypes.Toggle) && !IsFullScreen)
                 Unchecked?.Invoke(this, args);
         }
 
         public event RoutedEventHandler Tapped;
-        internal void RaiseTapped(RoutedEventArgs args) => Tapped?.Invoke(this, args);
+        internal void RaiseTapped(RoutedEventArgs args)
+        {
+            if (!IsFullScreen)
+                this.Tapped?.Invoke(this, args);
+        }
 
         public event RightTappedEventHandler RightTapped;
-        internal void RaiseRightTapped(Windows.UI.Xaml.Input.RightTappedRoutedEventArgs args) => RightTapped?.Invoke(this, args);
+        internal void RaiseRightTapped(Windows.UI.Xaml.Input.RightTappedRoutedEventArgs args)
+        {
+            if (!IsFullScreen)
+                this.RightTapped?.Invoke(this, args);
+        }
 
         public event HoldingEventHandler Holding;
-        internal void RaiseHolding(HoldingRoutedEventArgs args) => Holding?.Invoke(this, args);
+        internal void RaiseHolding(HoldingRoutedEventArgs args)
+        {
+            if (!IsFullScreen)
+                this.Holding?.Invoke(this, args);
+        }
 
         #endregion
     }

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -82,41 +82,41 @@
 
             <DataTemplate x:Name="NavButtonLiteralTemplate" x:DataType="local:HamburgerButtonInfo">
                 <ContentPresenter x:Name="ContentPresenter"
-                                  Width="{Binding PaneWidth, ElementName=ThisPage}"
+                                  Width="{Binding PaneWidth, ElementName=ThisPage, Mode=OneWay}"
                                   MinWidth="48"
-                                  MaxWidth="{x:Bind MaxWidth, Mode=TwoWay}"
+                                  MaxWidth="{Binding MaxWidth, Mode=OneWay}"
                                   Background="{Binding NavButtonBackground, ElementName=ThisPage, FallbackValue=DarkRed, Mode=OneWay}"
-                                  Content="{Binding Content}"
+                                  Content="{Binding Content, Mode=OneWay}"
                                   Foreground="{Binding NavButtonForeground, ElementName=ThisPage, FallbackValue=White, Mode=OneWay}"
                                   Loaded="NavButton_Loaded"
-                                  ToolTipService.ToolTip="{Binding Path=(ToolTipService.ToolTip)}"
-                                  Visibility="{Binding Visibility, Mode=TwoWay}" />
+                                  ToolTipService.ToolTip="{Binding Path=(ToolTipService.ToolTip), Mode=OneWay}"
+                                  Visibility="{Binding Visibility, Mode=OneWay}" />
             </DataTemplate>
 
             <DataTemplate x:Name="NavToggleButtonTemplate" x:DataType="local:HamburgerButtonInfo">
                 <ToggleButton Width="{Binding PaneWidth, ElementName=ThisPage}"
                               MinWidth="48"
-                              MaxWidth="{x:Bind MaxWidth, Mode=TwoWay}"
+                              MaxWidth="{Binding MaxWidth, Mode=OneWay}"
                               AutomationProperties.Name="Hamburger Menu Item"
-                              Checked="NavButtonChecked"
-                              Command="{Binding NavCommand, ElementName=ThisPage}"
-                              CommandParameter="{Binding}"
-                              Content="{Binding Content}"
+                              Checked="NavButton_Checked"
+                              Command="{Binding NavCommand, ElementName=ThisPage, Mode=OneWay}"
+                              CommandParameter="{Binding Mode=OneWay}"
+                              Content="{Binding Content, Mode=OneWay}"
                               Holding="NavButton_Holding"
                               IsChecked="{Binding IsChecked, Mode=TwoWay}"
-                              IsEnabled="{Binding IsEnabled, Mode=TwoWay}"
-                              IsTabStop="{Binding IsChecked, Converter={StaticResource ReverseBooleanConverter}}"
+                              IsEnabled="{Binding IsEnabled_InternalBinding, Mode=OneWay}"
+                              IsTabStop="{Binding IsTabStop_InternalBinding, Mode=OneWay}"
                               Loaded="NavButton_Loaded"
                               RightTapped="NavButton_RightTapped"
                               TabIndex="2"
                               Tapped="NavButton_Tapped"
-                              ToolTipService.ToolTip="{Binding Path=(ToolTipService.ToolTip)}"
-                              Unchecked="NavButtonUnchecked"
-                              Visibility="{Binding Visibility, Mode=TwoWay}">
+                              ToolTipService.ToolTip="{Binding Path=(ToolTipService.ToolTip), Mode=OneWay}"
+                              Unchecked="NavButton_Unchecked"
+                              Visibility="{Binding Visibility, Mode=OneWay}">
                     <ToggleButton.Template>
                         <ControlTemplate TargetType="ToggleButton">
                             <Grid x:Name="RootGrid"
-                                  Width="{Binding PaneWidth, ElementName=ThisPage}"
+                                  Width="{Binding PaneWidth, ElementName=ThisPage, Mode=OneWay}"
                                   Background="Transparent">
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
@@ -182,7 +182,7 @@
                                         <VisualState x:Name="IndeterminateDisabled" />
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
-                                <ContentPresenter x:Name="ContentPresenter" Content="{Binding Content}" />
+                                <ContentPresenter x:Name="ContentPresenter" Content="{Binding Content, Mode=OneWay}" />
                                 <Rectangle x:Name="Indicator"
                                            Width="4"
                                            HorizontalAlignment="Left"
@@ -195,27 +195,28 @@
             </DataTemplate>
 
             <DataTemplate x:Name="NavCommandButtonTemplate" x:DataType="local:HamburgerButtonInfo">
-                <Button Width="{Binding PaneWidth, ElementName=ThisPage}"
+                <Button Width="{Binding PaneWidth, ElementName=ThisPage, Mode=OneWay}"
                         MinWidth="48"
-                        MaxWidth="{x:Bind MaxWidth, Mode=OneWay}"
+                        MaxWidth="{Binding MaxWidth, Mode=OneWay}"
                         AutomationProperties.Name="Hamburger Menu Item"
                         BorderBrush="Red"
                         BorderThickness="1"
-                        Command="{Binding NavCommand, ElementName=ThisPage}"
-                        CommandParameter="{Binding}"
-                        Content="{x:Bind Content, Mode=OneWay}"
+                        Command="{Binding NavCommand, ElementName=ThisPage, Mode=OneWay}"
+                        CommandParameter="{Binding Mode=OneWay}"
+                        Content="{Binding Content, Mode=OneWay}"
                         Holding="NavButton_Holding"
-                        IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
+                        IsEnabled="{Binding IsEnabled_InternalBinding, Mode=OneWay}"
+                        IsTabStop="{Binding IsTabStop_InternalBinding, Mode=OneWay}"
                         Loaded="NavButton_Loaded"
                         RightTapped="NavButton_RightTapped"
                         TabIndex="2"
                         Tapped="NavButton_Tapped"
-                        ToolTipService.ToolTip="{x:Bind Path=(ToolTipService.ToolTip), Mode=OneWay}"
-                        Visibility="{x:Bind Visibility, Mode=OneWay}">
+                        ToolTipService.ToolTip="{Binding Path=(ToolTipService.ToolTip), Mode=OneWay}"
+                        Visibility="{Binding Visibility, Mode=OneWay}">
                     <Button.Template>
                         <ControlTemplate TargetType="Button">
                             <Grid x:Name="RootGrid"
-                                  Width="{Binding PaneWidth, ElementName=ThisPage}"
+                                  Width="{Binding PaneWidth, ElementName=ThisPage, Mode=OneWay}"
                                   Background="Transparent">
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
@@ -254,7 +255,7 @@
                                         </VisualState>
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
-                                <ContentPresenter x:Name="ContentPresenter" Content="{Binding Content}" />
+                                <ContentPresenter x:Name="ContentPresenter" Content="{Binding Content, Mode=OneWay}" />
                             </Grid>
                         </ControlTemplate>
                     </Button.Template>

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -581,9 +581,11 @@ namespace Template10.Controls
         // intended to be marshalled by UpdateControl()
         private void UpdateFullScreen(bool? manual = null)
         {
+            var isFullScreen = false;
             var opacity = 1;
             if (manual ?? IsFullScreen)
             {
+                isFullScreen = true;
                 opacity = 0;
                 if (DisplayMode == SplitViewDisplayMode.Overlay)
                 {
@@ -612,6 +614,18 @@ namespace Template10.Controls
             HamburgerButton.Opacity = opacity;
             HamburgerBackground.Opacity = opacity;
             PaneContent.Opacity = opacity;
+
+            // update tabstop settings
+            Header.IsTabStop = !isFullScreen;
+            HamburgerButton.IsTabStop = !isFullScreen;
+            foreach (var button in this.PrimaryButtons)
+            {
+                button.IsFullScreen = isFullScreen;
+            }
+            foreach (var button in this.SecondaryButtons)
+            {
+                button.IsFullScreen = isFullScreen;
+            }
         }
 
         // intended to be marshalled by UpdateControl()
@@ -673,20 +687,23 @@ namespace Template10.Controls
         {
             DebugWrite($"HamburgerButtonInfo: {commandInfo}");
 
-            if (commandInfo == null)
+            if (!IsFullScreen)
             {
-                throw new NullReferenceException("CommandParameter is not set");
-            }
+                if (commandInfo == null)
+                {
+                    throw new NullReferenceException("CommandParameter is not set");
+                }
 
-            if (commandInfo.PageType != null)
-            {
-                Selected = commandInfo;
-            }
-            else
-            {
-                ExecuteNavButtonICommand(commandInfo);
-                commandInfo.RaiseTapped(new RoutedEventArgs());
-                CommandButttonTapped?.Invoke(commandInfo, null);
+                if (commandInfo.PageType != null)
+                {
+                    Selected = commandInfo;
+                }
+                else
+                {
+                    ExecuteNavButtonICommand(commandInfo);
+                    commandInfo.RaiseTapped(new RoutedEventArgs());
+                    CommandButttonTapped?.Invoke(commandInfo, null);
+                }
             }
         }
         #endregion
@@ -743,7 +760,7 @@ namespace Template10.Controls
         private void ExecuteNavButtonICommand(HamburgerButtonInfo info)
         {
             ICommand command = info.Command;
-            if (command != null)
+            if (command != null && !this.IsFullScreen)
             {
                 var commandParameter = info.CommandParameter;
                 if (command.CanExecute(commandParameter))
@@ -771,7 +788,7 @@ namespace Template10.Controls
             e.Handled = true;
         }
 
-        private void NavButtonChecked(object sender, RoutedEventArgs e)
+        private void NavButton_Checked(object sender, RoutedEventArgs e)
         {
             DebugWrite();
 
@@ -785,7 +802,7 @@ namespace Template10.Controls
             }
         }
 
-        private void NavButtonUnchecked(object sender, RoutedEventArgs e)
+        private void NavButton_Unchecked(object sender, RoutedEventArgs e)
         {
             DebugWrite();
 


### PR DESCRIPTION
When HamburgerMenu is in FullScreen mode, disable HamburgerButtons to make sure that they're not reachable using keyboard/controller/shortcuts. Addresses #1334.