### PR TITLE
Add CreateNavigationService method to BootStrapper

### DIFF
--- a/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
+++ b/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
@@ -290,7 +290,7 @@ namespace Template10.Common
                 }
             }
 
-            var navigationService = new NavigationService(frame);
+            var navigationService = CreateNavigationService(frame);
             navigationService.BackButtonHandling = backButton;
             WindowWrapper.Current().NavigationServices.Add(navigationService);
 
@@ -331,6 +331,13 @@ namespace Template10.Common
             return navigationService;
         }
 
+        /// <summary>
+        /// Creates the NavigationService instance for given Frame.
+        /// </summary>
+        protected virtual INavigationService CreateNavigationService(Frame frame)
+        {
+            return new NavigationService(frame);
+        }
 
         private BootstrapperStates _currentState = BootstrapperStates.None;
         public BootstrapperStates CurrentState


### PR DESCRIPTION
Add CreateNavigationService method to BootStrapper. This method has been removed on latestet commits but we use it in our solutions. It was available in 1.1.12 and is missing in 1.1.13-preview20161207