### PR TITLE
Makes GoBack() and GoForWard() FrameFacade methods public.

### DIFF
--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -53,9 +53,9 @@ namespace Template10.Services.NavigationService
 
         public bool CanGoForward => _Frame.CanGoForward;
 
-        internal void GoBack(NavigationTransitionInfo infoOverride = null) => _Frame.GoBack();
+        public void GoBack(NavigationTransitionInfo infoOverride = null) => _Frame.GoBack();
 
-        internal void GoForward() => _Frame.GoForward();
+        public void GoForward() => _Frame.GoForward();
 
         public void ClearCache(bool removeCachedPagesInBackStack = false)
         {


### PR DESCRIPTION
Changes the access modifier from internal to public for GoBack() and GoForWard() FrameFacade methods.