### PR TITLE
HamburgerMenu - HighLightCorrectButton 

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -416,7 +416,8 @@ namespace Template10.Controls
 
                     // add parameter match
                     buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
-                    var newButton = buttons.Select(x => x.HamburgerButtonInfo).FirstOrDefault();
+                    var newButton = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
+                                           .Select(x => x.HamburgerButtonInfo).FirstOrDefault();
 
                     // Update selected button
                     var oldButton = Selected;

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -410,8 +410,8 @@ namespace Template10.Controls
 
             // add parameter match
             buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
-            var button = buttons.Select(x => x.HamburgerButtonInfo).FirstOrDefault();
-            Selected = button;
+            var button = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
+                                .Select(x => x.HamburgerButtonInfo).FirstOrDefault();
         }
 
         async Task ResetValueAsync(DependencyProperty prop, object tempValue, int wait = 50)

--- a/Templates (Project)/Hamburger/Views/Shell.xaml
+++ b/Templates (Project)/Hamburger/Views/Shell.xaml
@@ -52,8 +52,10 @@
             </Controls:HamburgerButtonInfo>
             <!--  settingspage button  -->
             <Controls:HamburgerButtonInfo x:Name="SettingsButton"
-                                          PageParameter="0"
                                           PageType="views:SettingsPage">
+                <Controls:HamburgerButtonInfo.PageParameter>
+                    <x:Int32>0</x:Int32>
+                </Controls:HamburgerButtonInfo.PageParameter>
                 <Controls:HamburgerButtonInfo.NavigationTransitionInfo>
                     <SuppressNavigationTransitionInfo />
                 </Controls:HamburgerButtonInfo.NavigationTransitionInfo>

--- a/Templates (Project)/Hamburger/Views/Shell.xaml
+++ b/Templates (Project)/Hamburger/Views/Shell.xaml
@@ -53,9 +53,6 @@
             <!--  settingspage button  -->
             <Controls:HamburgerButtonInfo x:Name="SettingsButton"
                                           PageType="views:SettingsPage">
-                <Controls:HamburgerButtonInfo.PageParameter>
-                    <x:Int32>0</x:Int32>
-                </Controls:HamburgerButtonInfo.PageParameter>
                 <Controls:HamburgerButtonInfo.NavigationTransitionInfo>
                     <SuppressNavigationTransitionInfo />
                 </Controls:HamburgerButtonInfo.NavigationTransitionInfo>


### PR DESCRIPTION
The request #1347 was based on old master branch code. I have re-create a fork to implement the code in the right version.

In the HamburgerMenu when a navigation starts, a search is started to find if a button exists to high light it.
The search criteria is first based on the type of the page and after on the PageParameter.
The select is based on 2 criterias: null or PageParameter equal to pageParam.
The error consists in the fact that if 2 buttons exist (one null and one with a parameter) the null is taken.
Introducing a OrderByDescending will force to select first the button matching the pageParam critieria.
       
`// add parameter match
        buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
        var button = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
                            .Select(x => x.HamburgerButtonInfo).FirstOrDefault();
        Selected = button;`
