### PR TITLE
Prevent unneccessary Navigation on "Back" caused by HighlightCorrectButton

### DIFF
--- a/Template10 (Library)/Controls/HamburgerButtonInfo.cs
+++ b/Template10 (Library)/Controls/HamburgerButtonInfo.cs
@@ -201,7 +201,7 @@ namespace Template10.Controls
 
         #region Internal binding properties
 
-        private void UpdateInternalBindingValues()
+        internal void UpdateInternalBindingValues()
         {
             bool isFullScreen = this.IsFullScreen;
             bool isEnabled = !isFullScreen && this.IsEnabled;

--- a/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
@@ -504,9 +504,13 @@ namespace Template10.Controls
             DependencyProperty.Register(nameof(Selected), typeof(HamburgerButtonInfo),
                 typeof(HamburgerMenu), new PropertyMetadata(null, (d, e) =>
                 {
-                    WriteDebug(nameof(Selected), e);
-                    (d as HamburgerMenu).SelectedChanged?.Invoke(d, e.ToChangedEventArgs<HamburgerButtonInfo>());
-                    (d as HamburgerMenu).InternalSelectedChanged(e.ToChangedEventArgs<HamburgerButtonInfo>());
+                    var hamburgerMenu = (d as HamburgerMenu);
+                    if (!hamburgerMenu._isHighlightCorrectButtonRunning)
+                    {
+                        WriteDebug(nameof(Selected), e);
+                        hamburgerMenu.SelectedChanged?.Invoke(d, e.ToChangedEventArgs<HamburgerButtonInfo>());
+                        hamburgerMenu.InternalSelectedChanged(e.ToChangedEventArgs<HamburgerButtonInfo>());
+                    }
                 }));
         public event EventHandler<ChangedEventArgs<HamburgerButtonInfo>> SelectedChanged;
         partial void InternalSelectedChanged(ChangedEventArgs<HamburgerButtonInfo> e);

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -387,31 +387,49 @@ namespace Template10.Controls
             }
         }
 
+        private bool _isHighlightCorrectButtonRunning;
         internal void HighlightCorrectButton(Type pageType, object pageParam)
         {
             DebugWrite($"PageType: {pageType} PageParam: {pageParam}");
-
-            // match type only
-            var buttons = LoadedNavButtons.Where(x => Equals(x.HamburgerButtonInfo.PageType, pageType));
-
-            // serialize parameter for matching
-            if (pageParam == null)
+            _isHighlightCorrectButtonRunning = true;
+            try
             {
-                pageParam = NavigationService.CurrentPageParam;
-            }
-            else if (pageParam.ToString().StartsWith("{"))
-            {
-                try
+                // match type only
+                var buttons = LoadedNavButtons.Where(x => Equals(x.HamburgerButtonInfo.PageType, pageType));
+                if (buttons.Any())
                 {
-                    pageParam = NavigationService.FrameFacade.SerializationService.Deserialize(pageParam.ToString());
-                }
-                catch { }
-            }
+                    // serialize parameter for matching
+                    if (pageParam == null)
+                    {
+                        pageParam = NavigationService.CurrentPageParam;
+                    }
+                    else if (pageParam.ToString().StartsWith("{"))
+                    {
+                        try
+                        {
+                            pageParam = NavigationService.FrameFacade.SerializationService.Deserialize(pageParam.ToString());
+                        }
+                        catch
+                        {
+                        }
+                    }
 
-            // add parameter match
-            buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
-            var button = buttons.Select(x => x.HamburgerButtonInfo).FirstOrDefault();
-            Selected = button;
+                    // add parameter match
+                    buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
+                    var newButton = buttons.Select(x => x.HamburgerButtonInfo).FirstOrDefault();
+
+                    // Update selected button
+                    var oldButton = Selected;
+                    if (oldButton != newButton)
+                    {
+                        Selected = newButton;
+                    }
+                }
+            }
+            finally
+            {
+                _isHighlightCorrectButtonRunning = false;
+            }
         }
 
         async Task ResetValueAsync(DependencyProperty prop, object tempValue, int wait = 50)

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -423,6 +423,16 @@ namespace Template10.Controls
                     if (oldButton != newButton)
                     {
                         Selected = newButton;
+                        oldButton?.UpdateInternalBindingValues();
+                        if (oldButton?.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle)
+                        {
+                            oldButton.IsChecked = false;
+                        }
+                    }
+                    newButton?.UpdateInternalBindingValues();
+                    if (newButton?.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle)
+                    {
+                        newButton.IsChecked = true;
                     }
                 }
             }


### PR DESCRIPTION
HighlightCorrectButton updates the Selected hamburger button, the property itself triggers methods and navigation requests. This causes some useless navigation events when "Back" button is used or on application startup. This PR will fix this, #1376 