### PR TITLE
An amended version of PR #1374 following a review by Jerry.

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -315,7 +315,7 @@ namespace Template10.Controls
 
             try
             {
-                await UpdateSelectedAsync(e.OldValue, e.NewValue);
+               if(!DoNotActuallyNavigate) await UpdateSelectedAsync(e.OldValue, e.NewValue);
             }
             catch (Exception ex)
             {
@@ -530,9 +530,11 @@ namespace Template10.Controls
             }
         }
 
-        private async Task UpdateSelectedAsync(HamburgerButtonInfo previous, HamburgerButtonInfo value)
+        private bool DoNotActuallyNavigate;
+
+        private async Task UpdateSelectedAsync(HamburgerButtonInfo previous, HamburgerButtonInfo current)
         {
-            DebugWrite($"OldValue: {previous}, NewValue: {value}");
+            DebugWrite($"OldValue: {previous}, NewValue: {current}");
 
             // pls. do not remove this if statement. this is the fix for #410 (click twice)
             if (previous != null)
@@ -541,63 +543,81 @@ namespace Template10.Controls
             }
 
             // signal previous
-            if (previous != null && previous != value && previous.IsChecked.Value)
+            if (previous != null && previous != current && previous.IsChecked.Value)
             {
-                previous.IsChecked = false;
-                previous.RaiseUnselected();
-
                 // Workaround for visual state of ToggleButton not reset correctly
-                if (value != null)
+                if (current != null)
                 {
-                    var control = LoadedNavButtons.First(x => x.HamburgerButtonInfo == value).GetElement<Control>();
+                    var control = LoadedNavButtons.First(x => x.HamburgerButtonInfo == current).GetElement<Control>();
                     VisualStateManager.GoToState(control, "Normal", true);
                 }
             }
 
             // navigate only when all navigation buttons have been loaded
-            if (AllNavButtonsAreLoaded && value?.PageType != null)
+            if (AllNavButtonsAreLoaded && current?.PageType != null)
             {
-                if (await NavigationService.NavigateAsync(value.PageType, value?.PageParameter, value?.NavigationTransitionInfo))
+                if (await NavigationService.NavigateAsync(current.PageType, current?.PageParameter, current?.NavigationTransitionInfo))
                 {
+                    SignalPreviousPage(previous, current);
+                    SignalCurrentPage(previous, current);
+
                     IsOpen = (DisplayMode == SplitViewDisplayMode.CompactInline && IsOpen);
-                    if (value.ClearHistory)
+                    if (current.ClearHistory)
                         NavigationService.ClearHistory();
-                    if (value.ClearCache)
+                    if (current.ClearCache)
                         NavigationService.ClearCache(true);
                 }
-                else if (NavigationService.CurrentPageType == value.PageType
-                     && (NavigationService.CurrentPageParam ?? string.Empty) == (value.PageParameter ?? string.Empty))
+                else if (NavigationService.CurrentPageType == current.PageType && (NavigationService.CurrentPageParam ?? string.Empty) == (current.PageParameter ?? string.Empty))
                 {
-                    if (value.ClearHistory)
+                    SignalPreviousPage(previous, current);
+                    SignalCurrentPage(previous, current);
+
+                    if (current.ClearHistory)
                         NavigationService.ClearHistory();
-                    if (value.ClearCache)
+                    if (current.ClearCache)
                         NavigationService.ClearCache(true);
                 }
-                else if (NavigationService.CurrentPageType == value.PageType)
+                else if (previous == null || NavigationService.CurrentPageType == current.PageType)
                 {
-                    // just check it
+                    SignalCurrentPage(previous, current);
                 }
                 else
                 {
+                    // Re-instate Selected to previous page, but avoid calling this method (UpdateSelectedAsync) all over
+                    // again, and we use a flag to effect this. See InternalSelectedChanged() method where it's used.
+
+                    DoNotActuallyNavigate = true;
+                    Selected = previous;
+                    DoNotActuallyNavigate = false;
+                    current.IsChecked = false;
+                    current.RaiseUnselected();
                     return;
                 }
             }
-
-            // that's it if null
-            if (value == null)
-            {
-                return;
-            }
             else
             {
-                value.IsChecked = (value.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle);
-                if (previous != value)
-                {
-                    value.RaiseSelected();
-                }
+                SignalPreviousPage(previous, current);
+                SignalCurrentPage(previous, current);
             }
         }
 
+        private void SignalPreviousPage(HamburgerButtonInfo previous, HamburgerButtonInfo current)
+        {
+            if (previous != null && previous != current && previous.IsChecked.Value)
+            {
+                previous.IsChecked = false;
+                previous.RaiseUnselected();
+            }
+        }
+        private void SignalCurrentPage(HamburgerButtonInfo previous, HamburgerButtonInfo current)
+        {
+            if (current == null) return;
+            current.IsChecked = (current.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle);
+            if (previous != current)
+            {
+                current.RaiseSelected();
+            }
+        }
 
         private void UpdateControl(bool? manualFullScreen = null)
         {


### PR DESCRIPTION
Amended as per your review @JerryNixon.

> Don't you think (current != null) belongs in SignalCurrentPage() instead of here?

Single exit point style?  ... had two minds about this but will stick to your suggestion. Done accordingly.

> Let's introduce a bool method IsSame(oldType, oldParam, newType, newParam).

Will do a new PR as suggested.

> I will say I regret you did these changes in this PR...

Thought changing **value** to **current** enhances code readability. That's the only existing var that has changed.
