### PR TITLE
Navigation service issue

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -416,7 +416,8 @@ namespace Template10.Controls
 
                     // add parameter match
                     buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
-                    var newButton = buttons.Select(x => x.HamburgerButtonInfo).FirstOrDefault();
+                    var newButton = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
+                                           .Select(x => x.HamburgerButtonInfo).FirstOrDefault();
 
                     // Update selected button
                     var oldButton = Selected;

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -410,8 +410,8 @@ namespace Template10.Controls
 
             // add parameter match
             buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
-            var button = buttons.Select(x => x.HamburgerButtonInfo).FirstOrDefault();
-            Selected = button;
+            var button = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
+                                .Select(x => x.HamburgerButtonInfo).FirstOrDefault();
         }
 
         async Task ResetValueAsync(DependencyProperty prop, object tempValue, int wait = 50)

--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -216,7 +216,8 @@ namespace Template10.Services.NavigationService
             // call newViewModel.ResolveForPage()
             if (newViewModel == null)
             {
-                newPage.DataContext = BootStrapper.Current.ResolveForPage(newPage, this);
+                newViewModel = BootStrapper.Current.ResolveForPage(newPage, this);
+                newPage.DataContext = newViewModel;
             }
 
             // call newTemplate10ViewModel.Properties

--- a/Templates (Project)/Hamburger/Views/Shell.xaml
+++ b/Templates (Project)/Hamburger/Views/Shell.xaml
@@ -52,8 +52,10 @@
             </Controls:HamburgerButtonInfo>
             <!--  settingspage button  -->
             <Controls:HamburgerButtonInfo x:Name="SettingsButton"
-                                          PageParameter="0"
                                           PageType="views:SettingsPage">
+                <Controls:HamburgerButtonInfo.PageParameter>
+                    <x:Int32>0</x:Int32>
+                </Controls:HamburgerButtonInfo.PageParameter>
                 <Controls:HamburgerButtonInfo.NavigationTransitionInfo>
                     <SuppressNavigationTransitionInfo />
                 </Controls:HamburgerButtonInfo.NavigationTransitionInfo>

--- a/Templates (Project)/Hamburger/Views/Shell.xaml
+++ b/Templates (Project)/Hamburger/Views/Shell.xaml
@@ -53,9 +53,6 @@
             <!--  settingspage button  -->
             <Controls:HamburgerButtonInfo x:Name="SettingsButton"
                                           PageType="views:SettingsPage">
-                <Controls:HamburgerButtonInfo.PageParameter>
-                    <x:Int32>0</x:Int32>
-                </Controls:HamburgerButtonInfo.PageParameter>
                 <Controls:HamburgerButtonInfo.NavigationTransitionInfo>
                     <SuppressNavigationTransitionInfo />
                 </Controls:HamburgerButtonInfo.NavigationTransitionInfo>


### PR DESCRIPTION
When navigation occurs and the newViewModel is null (use of n external ioc tool) the ResolvePage is called to retrieve a new view model but the instance is not set to the variable newViewModel. In consequence the call to             
// call newViewModel.OnNavigatedToAsync()
            await Navigation.NavedToAsync(newViewModel, mode, oldPage, oldPage?.GetType(), oldParameter, newPage, page, parameter);

is not complete because the view model is missing.

=> Solution

`
            // call newViewModel.ResolveForPage()
            if (newViewModel == null)
            {
                newViewModel = BootStrapper.Current.ResolveForPage(newPage, this);
                newPage.DataContext = newViewModel;
            }`
