### PR TITLE
HighlightCorrectButton did not unselect button when navigating to unknown View

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -394,6 +394,8 @@ namespace Template10.Controls
             _isHighlightCorrectButtonRunning = true;
             try
             {
+                HamburgerButtonInfo newButton = null;
+
                 // match type only
                 var buttons = LoadedNavButtons.Where(x => Equals(x.HamburgerButtonInfo.PageType, pageType));
                 if (buttons.Any())
@@ -418,23 +420,23 @@ namespace Template10.Controls
                     buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
                     var newButton = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
                                            .Select(x => x.HamburgerButtonInfo).FirstOrDefault();
+                }
 
-                    // Update selected button
-                    var oldButton = Selected;
-                    if (oldButton != newButton)
+                // Update selected button
+                var oldButton = Selected;
+                if (!ReferenceEquals(oldButton, newButton))
+                {
+                    Selected = newButton;
+                    oldButton?.UpdateInternalBindingValues();
+                    if (oldButton?.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle)
                     {
-                        Selected = newButton;
-                        oldButton?.UpdateInternalBindingValues();
-                        if (oldButton?.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle)
-                        {
-                            oldButton.IsChecked = false;
-                        }
+                        oldButton.IsChecked = false;
                     }
-                    newButton?.UpdateInternalBindingValues();
-                    if (newButton?.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle)
-                    {
-                        newButton.IsChecked = true;
-                    }
+                }
+                newButton?.UpdateInternalBindingValues();
+                if (newButton?.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle)
+                {
+                    newButton.IsChecked = true;
                 }
             }
             finally

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -427,17 +427,19 @@ namespace Template10.Controls
                 if (!ReferenceEquals(oldButton, newButton))
                 {
                     Selected = newButton;
-                    oldButton?.UpdateInternalBindingValues();
                     if (oldButton?.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle)
                     {
                         oldButton.IsChecked = false;
                     }
+                    if (newButton?.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle)
+                    {
+                        newButton.IsChecked = true;
+                    }
                 }
+
+                // Update internal binding values for both buttons
+                oldButton?.UpdateInternalBindingValues();
                 newButton?.UpdateInternalBindingValues();
-                if (newButton?.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle)
-                {
-                    newButton.IsChecked = true;
-                }
             }
             finally
             {

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -369,7 +369,7 @@ namespace Template10.Controls
             if (e.NewValue.FrameFacade.BackStack.Count == 0
                 && e.NewValue.Frame.Content != null
                 && BootStrapper.Current.SplashFactory != null
-                && BootStrapper.Current.OriginalActivatedArgs.PreviousExecutionState != Windows.ApplicationModel.Activation.ApplicationExecutionState.Terminated)
+                && BootStrapper.Current.PreviousExecutionState != Windows.ApplicationModel.Activation.ApplicationExecutionState.Terminated)
             {
                 var once = false;
                 UpdateControl(true);
@@ -418,7 +418,7 @@ namespace Template10.Controls
 
                     // add parameter match
                     buttons = buttons.Where(x => Equals(x.HamburgerButtonInfo.PageParameter, null) || Equals(x.HamburgerButtonInfo.PageParameter, pageParam));
-                    var newButton = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
+                    newButton = buttons.OrderByDescending(x => x.HamburgerButtonInfo.PageParameter)
                                            .Select(x => x.HamburgerButtonInfo).FirstOrDefault();
                 }
 


### PR DESCRIPTION
This PR fixes a regression in my latest changes. HighlightCorrectButton did not unselect the latest Button if a View is shown that is not known in the HamburgerMenu.