### PR TITLE
Adds an if condition not accounted for, namely (viewmodel != null) 

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -315,7 +315,7 @@ namespace Template10.Controls
 
             try
             {
-                await UpdateSelectedAsync(e.OldValue, e.NewValue);
+               if(!DoNotActuallyNavigate) await UpdateSelectedAsync(e.OldValue, e.NewValue);
             }
             catch (Exception ex)
             {
@@ -531,9 +531,11 @@ namespace Template10.Controls
             }
         }
 
-        private async Task UpdateSelectedAsync(HamburgerButtonInfo previous, HamburgerButtonInfo value)
+        private bool DoNotActuallyNavigate;
+
+        private async Task UpdateSelectedAsync(HamburgerButtonInfo previous, HamburgerButtonInfo current)
         {
-            DebugWrite($"OldValue: {previous}, NewValue: {value}");
+            DebugWrite($"OldValue: {previous}, NewValue: {current}");
 
             // pls. do not remove this if statement. this is the fix for #410 (click twice)
             if (previous != null)
@@ -542,63 +544,81 @@ namespace Template10.Controls
             }
 
             // signal previous
-            if (previous != null && previous != value && previous.IsChecked.Value)
+            if (previous != null && previous != current && previous.IsChecked.Value)
             {
-                previous.IsChecked = false;
-                previous.RaiseUnselected();
-
                 // Workaround for visual state of ToggleButton not reset correctly
-                if (value != null)
+                if (current != null)
                 {
-                    var control = LoadedNavButtons.First(x => x.HamburgerButtonInfo == value).GetElement<Control>();
+                    var control = LoadedNavButtons.First(x => x.HamburgerButtonInfo == current).GetElement<Control>();
                     VisualStateManager.GoToState(control, "Normal", true);
                 }
             }
 
             // navigate only when all navigation buttons have been loaded
-            if (AllNavButtonsAreLoaded && value?.PageType != null)
+            if (AllNavButtonsAreLoaded && current?.PageType != null)
             {
-                if (await NavigationService.NavigateAsync(value.PageType, value?.PageParameter, value?.NavigationTransitionInfo))
+                if (await NavigationService.NavigateAsync(current.PageType, current?.PageParameter, current?.NavigationTransitionInfo))
                 {
+                    SignalPreviousPage(previous, current);
+                    SignalCurrentPage(previous, current);
+
                     IsOpen = (DisplayMode == SplitViewDisplayMode.CompactInline && IsOpen);
-                    if (value.ClearHistory)
+                    if (current.ClearHistory)
                         NavigationService.ClearHistory();
-                    if (value.ClearCache)
+                    if (current.ClearCache)
                         NavigationService.ClearCache(true);
                 }
-                else if (NavigationService.CurrentPageType == value.PageType
-                     && (NavigationService.CurrentPageParam ?? string.Empty) == (value.PageParameter ?? string.Empty))
+                else if (NavigationService.CurrentPageType == current.PageType && (NavigationService.CurrentPageParam ?? string.Empty) == (current.PageParameter ?? string.Empty))
                 {
-                    if (value.ClearHistory)
+                    SignalPreviousPage(previous, current);
+                    SignalCurrentPage(previous, current);
+
+                    if (current.ClearHistory)
                         NavigationService.ClearHistory();
-                    if (value.ClearCache)
+                    if (current.ClearCache)
                         NavigationService.ClearCache(true);
                 }
-                else if (NavigationService.CurrentPageType == value.PageType)
+                else if (previous == null || NavigationService.CurrentPageType == current.PageType)
                 {
-                    // just check it
+                    SignalCurrentPage(previous, current);
                 }
                 else
                 {
+                    // Re-instate Selected to previous page, but avoid calling this method (UpdateSelectedAsync) all over
+                    // again, and we use a flag to effect this. See InternalSelectedChanged() method where it's used.
+
+                    DoNotActuallyNavigate = true;
+                    Selected = previous;
+                    DoNotActuallyNavigate = false;
+                    current.IsChecked = false;
+                    current.RaiseUnselected();
                     return;
                 }
             }
-
-            // that's it if null
-            if (value == null)
-            {
-                return;
-            }
             else
             {
-                value.IsChecked = (value.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle);
-                if (previous != value)
-                {
-                    value.RaiseSelected();
-                }
+                SignalPreviousPage(previous, current);
+                SignalCurrentPage(previous, current);
             }
         }
 
+        private void SignalPreviousPage(HamburgerButtonInfo previous, HamburgerButtonInfo current)
+        {
+            if (previous != null && previous != current && previous.IsChecked.Value)
+            {
+                previous.IsChecked = false;
+                previous.RaiseUnselected();
+            }
+        }
+        private void SignalCurrentPage(HamburgerButtonInfo previous, HamburgerButtonInfo current)
+        {
+            if (current == null) return;
+            current.IsChecked = (current.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle);
+            if (previous != current)
+            {
+                current.RaiseSelected();
+            }
+        }
 
         private void UpdateControl(bool? manualFullScreen = null)
         {

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -315,7 +315,7 @@ namespace Template10.Controls
 
             try
             {
-                await UpdateSelectedAsync(e.OldValue, e.NewValue);
+               if(!DoNotActuallyNavigate) await UpdateSelectedAsync(e.OldValue, e.NewValue);
             }
             catch (Exception ex)
             {
@@ -530,9 +530,11 @@ namespace Template10.Controls
             }
         }
 
-        private async Task UpdateSelectedAsync(HamburgerButtonInfo previous, HamburgerButtonInfo value)
+        private bool DoNotActuallyNavigate;
+
+        private async Task UpdateSelectedAsync(HamburgerButtonInfo previous, HamburgerButtonInfo current)
         {
-            DebugWrite($"OldValue: {previous}, NewValue: {value}");
+            DebugWrite($"OldValue: {previous}, NewValue: {current}");
 
             // pls. do not remove this if statement. this is the fix for #410 (click twice)
             if (previous != null)
@@ -541,63 +543,81 @@ namespace Template10.Controls
             }
 
             // signal previous
-            if (previous != null && previous != value && previous.IsChecked.Value)
+            if (previous != null && previous != current && previous.IsChecked.Value)
             {
-                previous.IsChecked = false;
-                previous.RaiseUnselected();
-
                 // Workaround for visual state of ToggleButton not reset correctly
-                if (value != null)
+                if (current != null)
                 {
-                    var control = LoadedNavButtons.First(x => x.HamburgerButtonInfo == value).GetElement<Control>();
+                    var control = LoadedNavButtons.First(x => x.HamburgerButtonInfo == current).GetElement<Control>();
                     VisualStateManager.GoToState(control, "Normal", true);
                 }
             }
 
             // navigate only when all navigation buttons have been loaded
-            if (AllNavButtonsAreLoaded && value?.PageType != null)
+            if (AllNavButtonsAreLoaded && current?.PageType != null)
             {
-                if (await NavigationService.NavigateAsync(value.PageType, value?.PageParameter, value?.NavigationTransitionInfo))
+                if (await NavigationService.NavigateAsync(current.PageType, current?.PageParameter, current?.NavigationTransitionInfo))
                 {
+                    SignalPreviousPage(previous, current);
+                    SignalCurrentPage(previous, current);
+
                     IsOpen = (DisplayMode == SplitViewDisplayMode.CompactInline && IsOpen);
-                    if (value.ClearHistory)
+                    if (current.ClearHistory)
                         NavigationService.ClearHistory();
-                    if (value.ClearCache)
+                    if (current.ClearCache)
                         NavigationService.ClearCache(true);
                 }
-                else if (NavigationService.CurrentPageType == value.PageType
-                     && (NavigationService.CurrentPageParam ?? string.Empty) == (value.PageParameter ?? string.Empty))
+                else if (NavigationService.CurrentPageType == current.PageType && (NavigationService.CurrentPageParam ?? string.Empty) == (current.PageParameter ?? string.Empty))
                 {
-                    if (value.ClearHistory)
+                    SignalPreviousPage(previous, current);
+                    SignalCurrentPage(previous, current);
+
+                    if (current.ClearHistory)
                         NavigationService.ClearHistory();
-                    if (value.ClearCache)
+                    if (current.ClearCache)
                         NavigationService.ClearCache(true);
                 }
-                else if (NavigationService.CurrentPageType == value.PageType)
+                else if (previous == null || NavigationService.CurrentPageType == current.PageType)
                 {
-                    // just check it
+                    SignalCurrentPage(previous, current);
                 }
                 else
                 {
+                    // Re-instate Selected to previous page, but avoid calling this method (UpdateSelectedAsync) all over
+                    // again, and we use a flag to effect this. See InternalSelectedChanged() method where it's used.
+
+                    DoNotActuallyNavigate = true;
+                    Selected = previous;
+                    DoNotActuallyNavigate = false;
+                    current.IsChecked = false;
+                    current.RaiseUnselected();
                     return;
                 }
             }
-
-            // that's it if null
-            if (value == null)
-            {
-                return;
-            }
             else
             {
-                value.IsChecked = (value.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle);
-                if (previous != value)
-                {
-                    value.RaiseSelected();
-                }
+                SignalPreviousPage(previous, current);
+                SignalCurrentPage(previous, current);
             }
         }
 
+        private void SignalPreviousPage(HamburgerButtonInfo previous, HamburgerButtonInfo current)
+        {
+            if (previous != null && previous != current && previous.IsChecked.Value)
+            {
+                previous.IsChecked = false;
+                previous.RaiseUnselected();
+            }
+        }
+        private void SignalCurrentPage(HamburgerButtonInfo previous, HamburgerButtonInfo current)
+        {
+            if (current == null) return;
+            current.IsChecked = (current.ButtonType == HamburgerButtonInfo.ButtonTypes.Toggle);
+            if (previous != current)
+            {
+                current.RaiseSelected();
+            }
+        }
 
         private void UpdateControl(bool? manualFullScreen = null)
         {

--- a/Template10 (Library)/Services/NavigationService/NavigationLogic.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationLogic.cs
@@ -171,6 +171,10 @@ namespace Template10.Services.NavigationService
                 var vm = viewmodel as Portable.IConfirmNavigationAsync;
                 return !await vm?.CanNavigateAsync(parameters);
             }
+            else if (viewmodel != null)
+            {
+                return false;
+            }
             else
             {
                 return true;

--- a/Template10 (Library)/Services/NavigationService/NavigationLogic.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationLogic.cs
@@ -171,10 +171,6 @@ namespace Template10.Services.NavigationService
                 var vm = viewmodel as Portable.IConfirmNavigationAsync;
                 return !await vm?.CanNavigateAsync(parameters);
             }
-            else if (viewmodel != null)
-            {
-                return false;
-            }
             else
             {
                 return true;


### PR DESCRIPTION
The if  condition in question is based on view pages's DataContext (usually ViewModel) but what if it's a different kind of DataContext? You may be testing something different but a good idea to account for DataContext that is not for a ViewModel. I discovered this in the process of changing a view page to view-model and the page had a DataContext set in codebehind - took me a while to figure out the strange behavior as T10's navigation returns true on exhausting the if condition test.

Better return false same as the `else if (viewmodel == null)`.  Is this related to #1380? May be the same from a different angle?