### PR TITLE
Adds an 'if condition' unaccounted for, namely (viewmodel != null).

### DIFF
--- a/Template10 (Library)/Services/NavigationService/NavigationLogic.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationLogic.cs
@@ -171,6 +171,10 @@ namespace Template10.Services.NavigationService
                 var vm = viewmodel as Portable.IConfirmNavigationAsync;
                 return !await vm?.CanNavigateAsync(parameters);
             }
+            else if (viewmodel != null)
+            {
+                return false;
+            }
             else
             {
                 return true;


### PR DESCRIPTION
The if condition in question is based on view pages's DataContext (usually ViewModel) but what if it's a different kind of DataContext? You may be testing something different but a good idea to account for a DataContext that is not for a ViewModel.

I discovered this in the process of adding a viewmodel and the view page had a DataContext of different type set in code-behind (and a while in existence) - took me sometime to figure out a strange behavior as T10's navigation returns true on exhausting the if condition test.

Is this related to #1380? I think it's and same problem from a different angle?