### PR TITLE
Sample SettingsPage.OnNavigatedTo() defends against calling ToString …

### DIFF
--- a/Samples/DynamicThemes/Views/SettingsPage.xaml.cs
+++ b/Samples/DynamicThemes/Views/SettingsPage.xaml.cs
@@ -15,8 +15,11 @@ namespace Sample.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            var index = int.Parse(_SerializationService.Deserialize(e.Parameter?.ToString()).ToString());
-            MyPivot.SelectedIndex = index;
-        }
-    }
+			if (e.Parameter != null)
+			{
+				var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
+				MyPivot.SelectedIndex = index;
+			}
+		}
+	}
 }

--- a/Samples/DynamicThemes/Views/SettingsPage.xaml.cs
+++ b/Samples/DynamicThemes/Views/SettingsPage.xaml.cs
@@ -15,11 +15,11 @@ namespace Sample.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-			if (e.Parameter != null)
-			{
-				var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
-				MyPivot.SelectedIndex = index;
-			}
-		}
-	}
+            if (e.Parameter != null)
+            {
+                var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
+                MyPivot.SelectedIndex = index;
+            }
+        }
+    }
 }

--- a/Samples/MultiplePageHeaders/Views/SettingsPage.xaml.cs
+++ b/Samples/MultiplePageHeaders/Views/SettingsPage.xaml.cs
@@ -16,8 +16,11 @@ namespace MultiplePageHeaders.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            var index = int.Parse(_SerializationService.Deserialize(e.Parameter?.ToString()).ToString());
-            MyPivot.SelectedIndex = index;
-        }
-    }
+			if (e.Parameter != null)
+			{
+				var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
+				MyPivot.SelectedIndex = index;
+			}
+		}
+	}
 }

--- a/Samples/MultiplePageHeaders/Views/SettingsPage.xaml.cs
+++ b/Samples/MultiplePageHeaders/Views/SettingsPage.xaml.cs
@@ -16,11 +16,11 @@ namespace MultiplePageHeaders.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-			if (e.Parameter != null)
-			{
-				var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
-				MyPivot.SelectedIndex = index;
-			}
-		}
-	}
+            if (e.Parameter != null)
+            {
+                var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
+                MyPivot.SelectedIndex = index;
+            }
+        }
+    }
 }

--- a/Templates (Project)/Hamburger/Views/SettingsPage.xaml.cs
+++ b/Templates (Project)/Hamburger/Views/SettingsPage.xaml.cs
@@ -17,8 +17,11 @@ namespace Sample.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            var index = int.Parse(_SerializationService.Deserialize(e.Parameter?.ToString()).ToString());
-            MyPivot.SelectedIndex = index;
+            if (e.Parameter != null)
+            {
+                var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString()).ToString());
+                MyPivot.SelectedIndex = index;
+            }
         }
     }
 }

--- a/Templates (Project)/Hamburger/Views/SettingsPage.xaml.cs
+++ b/Templates (Project)/Hamburger/Views/SettingsPage.xaml.cs
@@ -17,11 +17,11 @@ namespace Sample.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (e.Parameter != null)
-            {
-                var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString()).ToString());
-                MyPivot.SelectedIndex = index;
-            }
-        }
-    }
+			if (e.Parameter != null)
+			{
+				var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
+				MyPivot.SelectedIndex = index;
+			}
+		}
+	}
 }

--- a/Templates (Project)/Hamburger/Views/SettingsPage.xaml.cs
+++ b/Templates (Project)/Hamburger/Views/SettingsPage.xaml.cs
@@ -17,11 +17,11 @@ namespace Sample.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-			if (e.Parameter != null)
-			{
-				var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
-				MyPivot.SelectedIndex = index;
-			}
-		}
-	}
+            if (e.Parameter != null)
+            {
+                var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
+                MyPivot.SelectedIndex = index;
+            }
+        }
+    }
 }

--- a/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
+++ b/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
@@ -17,8 +17,11 @@ namespace Sample.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            var index = int.Parse(_SerializationService.Deserialize(e.Parameter?.ToString()).ToString());
-            MyPivot.SelectedIndex = index;
+            if (e.Parameter != null)
+            {
+                var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString()).ToString());
+                MyPivot.SelectedIndex = index;
+            }
         }
     }
 }

--- a/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
+++ b/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
@@ -17,11 +17,11 @@ namespace Sample.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (e.Parameter != null)
-            {
-                var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString()).ToString());
-                MyPivot.SelectedIndex = index;
-            }
-        }
-    }
+			if (e.Parameter != null)
+			{
+				var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
+				MyPivot.SelectedIndex = index;
+			}
+		}
+	}
 }

--- a/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
+++ b/Templates (Project)/Minimal/Views/SettingsPage.xaml.cs
@@ -17,11 +17,11 @@ namespace Sample.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-			if (e.Parameter != null)
-			{
-				var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
-				MyPivot.SelectedIndex = index;
-			}
-		}
-	}
+            if (e.Parameter != null)
+            {
+                var index = int.Parse(_SerializationService.Deserialize(e.Parameter.ToString())?.ToString() ?? "0");
+                MyPivot.SelectedIndex = index;
+            }
+        }
+    }
 }


### PR DESCRIPTION
…on a null e.Parameters, but then calls ToString() on the result of Deserialize(null) which is also null.

A recent change removed the parameter from the navigate in Shell.xaml