### PR TITLE
Use "await DispatchAsync" instead of "await Dispatch" when returning a task

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -368,7 +368,7 @@ namespace Template10.Controls
         {
             // If splash screen then continue showing until navigated once
             if (e.NewValue.FrameFacade.BackStack.Count == 0
-                && e.NewValue.Frame.Content != null
+                && e.NewValue.FrameFacade.Content != null
                 && BootStrapper.Current.SplashFactory != null
                 && BootStrapper.Current.PreviousExecutionState != Windows.ApplicationModel.Activation.ApplicationExecutionState.Terminated)
             {
@@ -410,7 +410,7 @@ namespace Template10.Controls
                     {
                         try
                         {
-                            pageParam = NavigationService.FrameFacade.SerializationService.Deserialize(pageParam.ToString());
+                            pageParam = NavigationService.SerializationService.Deserialize(pageParam.ToString());
                         }
                         catch
                         {

--- a/Template10 (Library)/Services/NavigationService/FrameFacade.cs
+++ b/Template10 (Library)/Services/NavigationService/FrameFacade.cs
@@ -66,7 +66,7 @@ namespace Template10.Services.NavigationService
             {
                 if (removeCachedPagesInBackStack)
                 {
-                    Frame.CacheSize = 0;
+                    _Frame.CacheSize = 0;
                 }
                 else
                 {

--- a/Template10 (Library)/Services/ViewService/ViewService.cs
+++ b/Template10 (Library)/Services/ViewService/ViewService.cs
@@ -38,7 +38,7 @@ namespace Template10.Services.ViewService
 
             var newView = CoreApplication.CreateNewView();
             var dispatcher = new DispatcherWrapper(newView.Dispatcher);
-            var newControl = await dispatcher.Dispatch(async () =>
+            var newControl = await dispatcher.DispatchAsync(async () =>
             {
                 var control = ViewLifetimeControl.GetForCurrentView();
                 var newWindow = Window.Current;


### PR DESCRIPTION
Use "await DispatchAsync" instead of "await Dispatch" when the inner method is returning a task. Because you want to await the inner task in the dispatcher and the outer task is awaiting the dispatcher. If you use Dispatch, when you will return the task and await it from outside. This is wrong.