### PR TITLE
Workaround for too large State Manager setting

### DIFF
--- a/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
+++ b/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
@@ -699,7 +699,23 @@ namespace Template10.Common
                     {
                         // individual frame-level
                         await nav.SuspendingAsync();
-                        if (AutoSuspendAllFrames) await nav.SaveAsync();
+                        if (AutoSuspendAllFrames)
+                        {
+                            try
+                            {
+                                await nav.SaveAsync();
+                            }
+                            catch
+                            {
+                                var frameState = nav.Suspension.GetFrameState();
+                                if (frameState != null)
+                                {
+                                    frameState.Remove("CurrentPageType");
+                                    frameState.Remove("CurrentPageParam");
+                                    frameState.Remove("NavigateState");
+                                }
+                            }
+                        }
                     }
 
                     // application-level

--- a/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
+++ b/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
@@ -714,6 +714,7 @@ namespace Template10.Common
                                     frameState.Remove("CurrentPageParam");
                                     frameState.Remove("NavigateState");
                                 }
+                                Exit();
                             }
                         }
                     }

--- a/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
+++ b/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
@@ -732,17 +732,17 @@ namespace Template10.Common
 
         private void SetupKeyboardListeners()
         {
-            var KeyboardService = Services.KeyboardService.KeyboardService.Instance;
-            KeyboardService.AfterBackGesture = () =>
+            var keyboardService = Services.KeyboardService.KeyboardService.Instance;
+            keyboardService.AfterBackGesture = () =>
             {
-                DebugWrite(caller: nameof(KeyboardService.AfterBackGesture));
+                DebugWrite(caller: nameof(keyboardService.AfterBackGesture));
 
                 var handled = false;
                 RaiseBackRequested(ref handled);
             };
-            KeyboardService.AfterForwardGesture = () =>
+            keyboardService.AfterForwardGesture = () =>
             {
-                DebugWrite(caller: nameof(KeyboardService.AfterForwardGesture));
+                DebugWrite(caller: nameof(keyboardService.AfterForwardGesture));
 
                 RaiseForwardRequested();
             };


### PR DESCRIPTION
Workaround: If state manager setting cannot be written on suspend, clear the values and exit the App to force a clean startup next time.