### PR TITLE
Add ChangeCursorAction

### DIFF
--- a/Template10.Core/Template10.Core.Behaviors/Behaviors/ChangeCursorAction.cs
+++ b/Template10.Core/Template10.Core.Behaviors/Behaviors/ChangeCursorAction.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Xaml.Interactivity;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+
+namespace Template10.Behaviors.Behaviors
+{
+    public class CursorBehavior : DependencyObject, IAction
+    {
+        public CoreCursorType Cursor { get; set; } = CoreCursorType.Arrow;
+
+        public object Execute(object sender, object parameter)
+        {
+            Window.Current.CoreWindow.PointerCursor = new CoreCursor(Cursor, 0);
+            return null;
+        }
+    }
+}

--- a/Template10.Core/Template10.Core.Behaviors/Template10.Behaviors.csproj
+++ b/Template10.Core/Template10.Core.Behaviors/Template10.Behaviors.csproj
@@ -108,6 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Behaviors\BackButtonBehavior.cs" />
+    <Compile Include="Behaviors\ChangeCursorAction.cs" />
     <Compile Include="Behaviors\CloseFlyoutAction.cs" />
     <Compile Include="Behaviors\ConditionalAction.cs" />
     <Compile Include="Behaviors\DeviceDispositionBehavior.cs" />


### PR DESCRIPTION
An action I frequently use in apps is changing the cursor when hovering over an element. Currently this requires you to handle the `PointerEntered` and `PointerExited` events, then set the cursor.
This PR adds an action to `Behaviors` which allows you to set the cursor in XAML. E.g.

    <Grid>
        <interactivity:Interaction.Behaviors>
            <core:EventTriggerBehavior EventName="PointerEntered">
                <behaviors:ChangeCursorAction Cursor="Hand" />
            </core:EventTriggerBehavior>
            <core:EventTriggerBehavior EventName="PointerExited">
                <behaviors:ChangeCursorAction Cursor="Arrow" />
            </core:EventTriggerBehavior>
        </interactivity:Interaction.Behaviors>
    </Grid>