### PR TITLE
Fix incorrect namespace

### DIFF
--- a/Template10.Core/Template10.Core.Behaviors/Behaviors/ChangeCursorAction.cs
+++ b/Template10.Core/Template10.Core.Behaviors/Behaviors/ChangeCursorAction.cs
@@ -2,7 +2,7 @@
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 
-namespace Template10.Behaviors.Behaviors
+namespace Template10.Behaviors
 {
     public class CursorBehavior : DependencyObject, IAction
     {


### PR DESCRIPTION
The simplest things are the hardest...
When I did an `Add > Class` I forgot to change the assigned namespace, resulting in too deep a nesting.
This corrects the issue.