### PR TITLE
Fix issue with HamburgerMenu when dynamically adding/removing buttons (#1516)

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.xaml
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml
@@ -89,6 +89,7 @@
                                   Content="{Binding Content}"
                                   Foreground="{Binding NavButtonForeground, ElementName=ThisPage, FallbackValue=White, Mode=OneWay}"
                                   Loaded="NavButton_Loaded"
+                                  Unloaded="NavButton_Unloaded"
                                   ToolTipService.ToolTip="{Binding Path=(ToolTipService.ToolTip)}"
                                   Visibility="{Binding Visibility, Mode=TwoWay}" />
             </DataTemplate>
@@ -107,6 +108,7 @@
                               IsEnabled="{Binding IsEnabled, Mode=TwoWay}"
                               IsTabStop="{Binding IsChecked, Converter={StaticResource ReverseBooleanConverter}}"
                               Loaded="NavButton_Loaded"
+                              Unloaded="NavButton_Unloaded"
                               RightTapped="NavButton_RightTapped"
                               TabIndex="2"
                               Tapped="NavButton_Tapped"
@@ -207,6 +209,7 @@
                         Holding="NavButton_Holding"
                         IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                         Loaded="NavButton_Loaded"
+                        Unloaded="NavButton_Unloaded"
                         RightTapped="NavButton_RightTapped"
                         TabIndex="2"
                         Tapped="NavButton_Tapped"

--- a/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.xaml.cs
@@ -740,6 +740,21 @@ namespace Template10.Controls
             }
         }
 
+        private void NavButton_Unloaded(object sender, RoutedEventArgs e)
+        {
+            DebugWrite();
+
+            var button = new InfoElement(sender);
+            if (LoadedNavButtons.Any(x => x.FrameworkElement == button.FrameworkElement))
+            {
+                LoadedNavButtons.Remove(LoadedNavButtons.Last(x => x.FrameworkElement == button.FrameworkElement));
+                if (AllNavButtonsAreLoaded)
+                {
+                    HighlightCorrectButton(NavigationService.CurrentPageType, NavigationService.CurrentPageParam);
+                }
+            }
+        }
+
         private void ExecuteNavButtonICommand(HamburgerButtonInfo info)
         {
             ICommand command = info.Command;


### PR DESCRIPTION
Keeping the button in the LoadedNavButtons caused issues when adding a button with the same PageType and Parameter again, throwing NullReferenceExceptions when trying to navigate. Fixed by adding a NavButton_Unloaded event, in which the unloaded button is removed from LoadedNavButtons.

Issue #1516 