### PR TITLE
OnNavigatedToAsync() not called when overriding ResolveForPage()

### DIFF
--- a/Template10 (Library)/Services/NavigationService/NavigationService.cs
+++ b/Template10 (Library)/Services/NavigationService/NavigationService.cs
@@ -202,7 +202,7 @@ namespace Template10.Services.NavigationService
             // call newViewModel.ResolveForPage()
             if (newViewModel == null)
             {
-                newPage.DataContext = BootStrapper.Current.ResolveForPage(newPage, this);
+                newViewModel = newPage.DataContext = BootStrapper.Current.ResolveForPage(newPage, this);
             }
 
             // call newTemplate10ViewModel.Properties


### PR DESCRIPTION
When overriding ResolveForPage() in App.xaml.cs in order to instantiate viewmodels in an MVVM architecture, the OnNavigatedToAsync() method is never called and the resulting viewmodel has a null NavigationService.

Assigning the newViewModel variable in NavigationService.NavigationOrchestratorAsync() means that the following call to NavToAsync() does not short circuit due to viewmodel being null. This in turn means the viewmodels OnNavigatedToAsync method gets called and the viewmodels NavigationService property gets set correctly.