### PR TITLE
Fixes a simple XAML typo that's difficult to locate!

### DIFF
--- a/Controls/Template10.Controls.PageHeader/Themes/Generic.xaml
+++ b/Controls/Template10.Controls.PageHeader/Themes/Generic.xaml
@@ -235,7 +235,7 @@
                                                     </VisualState>
                                                     <VisualState x:Name="Disabled">
                                                         <VisualState.Setters>
-                                                            <Setter Target="RootGrid.Foreground" Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
+															<Setter Target="RootGrid.Background" Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
                                                         </VisualState.Setters>
                                                     </VisualState>
                                                 </VisualStateGroup>


### PR DESCRIPTION
This took me a while to uncover but quite instructive: `RootGrid.Foreground` instead of `RootGrid.Background` in Generic.xaml.

We know that the  **Grid** has no **Foreground** property and Visual Studio couldn't detect this for blue underline. Interestingly, the error will show up only if you opt to show the BackButton in the PageHeader but then gives no clue where it originates.
