### PR TITLE
Fixes a non-collapsing width related to AppBarButton in PageHeader Control (1.1.12_vs2017)

### DIFF
--- a/Template10 (Library)/Controls/PageHeader.cs
+++ b/Template10 (Library)/Controls/PageHeader.cs
@@ -107,6 +107,15 @@ namespace Template10.Controls
             DependencyProperty.Register(nameof(PrimaryCommandsVisibility), typeof(Visibility),
                 typeof(PageHeader), new PropertyMetadata(Visibility.Visible));
 
+        public double ContentWidth
+        {
+            get { return (double)GetValue(ContentWidthProperty); }
+            set { SetValue(ContentWidthProperty, value); }
+        }
+        public static readonly DependencyProperty ContentWidthProperty =
+            DependencyProperty.Register(nameof(ContentWidth), typeof(double),
+                typeof(PageHeader), new PropertyMetadata(double.NaN));
+
         public Visibility BackButtonVisibility
         {
             get { return (Visibility)GetValue(BackButtonVisibilityProperty); }

--- a/Template10 (Library)/Themes/PageHeader.xaml
+++ b/Template10 (Library)/Themes/PageHeader.xaml
@@ -888,6 +888,7 @@
                                                 VerticalAlignment="Top"
                                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                Width="{TemplateBinding ContentWidth}"
                                                 Content="{TemplateBinding Content}"
                                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                                 ContentTransitions="{TemplateBinding ContentTransitions}"


### PR DESCRIPTION
Does same PR for 10.2 master branch, this time for version_1.1.12_vs2017.
- See #1548 for more info.