### PR TITLE
Fix HamburgerMenu and Back navigation issue, issue #1557

### DIFF
--- a/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
+++ b/Template10 (Library)/Controls/HamburgerMenu.PublicProperties.xaml.cs
@@ -491,8 +491,8 @@ namespace Template10.Controls
                 typeof(HamburgerMenu), new PropertyMetadata(null, (d, e) =>
                 {
                     WriteDebug(nameof(Selected), e);
-                    (d as HamburgerMenu).SelectedChanged?.Invoke(d, e.ToChangedEventArgs<HamburgerButtonInfo>());
                     (d as HamburgerMenu).InternalSelectedChanged(e.ToChangedEventArgs<HamburgerButtonInfo>());
+                    (d as HamburgerMenu).SelectedChanged?.Invoke(d, e.ToChangedEventArgs<HamburgerButtonInfo>());
                 }));
         public event EventHandler<ChangedEventArgs<HamburgerButtonInfo>> SelectedChanged;
         partial void InternalSelectedChanged(ChangedEventArgs<HamburgerButtonInfo> e);


### PR DESCRIPTION
Fix HamburgerMenu and Back navigation issue that sometimes caused wrong NavigationMode on ViewModels, because the navigation was double-triggered by the HamburgerMenu with NavigationMode.New and the wrong event was fired first. The original navigation with NavigationMode.Back was dropped.

It was very hard to get the correct timing with the event handlers and the "async void" event handler implementations. I hope this works correctly, please test carefully. It should fix #1557.