### PR TITLE
Add dispatcher awaits for better debugging, missing method, move delay into delegates

### DIFF
--- a/Template10 (Library)/Common/DispatcherWrapper/DispatcherWrapper.cs
+++ b/Template10 (Library)/Common/DispatcherWrapper/DispatcherWrapper.cs
@@ -40,7 +40,7 @@ namespace Template10.Common
                 if (delayms > 0)
                     await Task.Delay(delayms).ConfigureAwait(false);
                 var tcs = new TaskCompletionSource<T>();
-                dispatcher.RunAsync(priority, async delegate
+                await dispatcher.RunAsync(priority, async delegate
                 {
                     try
                     {
@@ -69,7 +69,7 @@ namespace Template10.Common
                 if (delayms > 0)
                     await Task.Delay(delayms).ConfigureAwait(false);
                 var tcs = new TaskCompletionSource<object>();
-                dispatcher.RunAsync(priority, delegate
+                await dispatcher.RunAsync(priority, delegate
                 {
                     try
                     {
@@ -98,7 +98,7 @@ namespace Template10.Common
                 if (delayms > 0)
                     await Task.Delay(delayms).ConfigureAwait(false);
                 var tcs = new TaskCompletionSource<object>();
-                dispatcher.RunAsync(priority, async delegate
+                await dispatcher.RunAsync(priority, async delegate
                 {
                     try
                     {
@@ -127,7 +127,7 @@ namespace Template10.Common
                 if (delayms > 0)
                     await Task.Delay(delayms).ConfigureAwait(false);
                 var tcs = new TaskCompletionSource<T>();
-                dispatcher.RunAsync(priority, delegate
+                await dispatcher.RunAsync(priority, delegate
                 {
                     try
                     {
@@ -191,7 +191,7 @@ namespace Template10.Common
                 if (delayms > 0)
                     await Task.Delay(delayms).ConfigureAwait(false);
                 var tcs = new TaskCompletionSource<object>();
-                dispatcher.RunIdleAsync(delegate
+                await dispatcher.RunIdleAsync(delegate
                 {
                     try
                     {
@@ -220,7 +220,7 @@ namespace Template10.Common
                 if (delayms > 0)
                     await Task.Delay(delayms).ConfigureAwait(false);
                 var tcs = new TaskCompletionSource<object>();
-                dispatcher.RunIdleAsync(async delegate
+                await dispatcher.RunIdleAsync(async delegate
                 {
                     try
                     {

--- a/Template10 (Library)/Common/DispatcherWrapper/DispatcherWrapper.cs
+++ b/Template10 (Library)/Common/DispatcherWrapper/DispatcherWrapper.cs
@@ -144,10 +144,12 @@ namespace Template10.Common
 
         public void Dispatch(Action action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
-            if (delayms > 0)
-                Task.Delay(delayms).ConfigureAwait(false).GetAwaiter().GetResult();
-
-            dispatcher.RunAsync(priority, () => action());
+            dispatcher.RunAsync(priority, async delegate
+			{
+				if (delayms > 0)
+					await Task.Delay(delayms).ConfigureAwait(true);
+				action();
+			});
         }
 
         public T Dispatch<T>(Func<T> action, int delayms = 0, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
@@ -279,10 +281,12 @@ namespace Template10.Common
 
         public void DispatchIdle(Action action, int delayms = 0)
         {
-            if (delayms > 0)
-                Task.Delay(delayms).ConfigureAwait(false).GetAwaiter().GetResult();
-
-            dispatcher.RunIdleAsync(args => action());
+            dispatcher.RunIdleAsync(async delegate
+			{
+				if (delayms > 0)
+					await Task.Delay(delayms).ConfigureAwait(true);
+				action();
+			});
         }
 
         public T DispatchIdle<T>(Func<T> action, int delayms = 0) where T : class

--- a/Template10 (Library)/Common/DispatcherWrapper/DispatcherWrapper.cs
+++ b/Template10 (Library)/Common/DispatcherWrapper/DispatcherWrapper.cs
@@ -256,6 +256,27 @@ namespace Template10.Common
             return await tcs.Task.ConfigureAwait(false);
         }
 
+        public async Task<T> DispatchIdleAsync<T>(Func<Task<T>> func, int delayms = 0)
+        {
+            if (delayms > 0)
+                await Task.Delay(delayms).ConfigureAwait(this.dispatcher.HasThreadAccess);
+
+            var tcs = new TaskCompletionSource<T>();
+            dispatcher.RunIdleAsync(async delegate
+            {
+                try
+                {
+                    var result = await func().ConfigureAwait(false);
+                    tcs.TrySetResult(result);
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            });
+            return await tcs.Task.ConfigureAwait(false);
+        }
+
         public void DispatchIdle(Action action, int delayms = 0)
         {
             if (delayms > 0)

--- a/Template10 (Library)/Common/DispatcherWrapper/IDispatcherWrapper.cs
+++ b/Template10 (Library)/Common/DispatcherWrapper/IDispatcherWrapper.cs
@@ -19,6 +19,7 @@ namespace Template10.Common
         Task DispatchIdleAsync(Func<Task> func, int delayms = 0);
         Task DispatchIdleAsync(Action action, int delayms = 0);
         Task<T> DispatchIdleAsync<T>(Func<T> func, int delayms = 0);
+        Task<T> DispatchIdleAsync<T>(Func<Task<T>> func, int delayms = 0);
 
         bool HasThreadAccess();
     }


### PR DESCRIPTION
The "awaits" were removed in #1583 and are not really neccessary, because the delegate is added to the dispatcher and not executed directly, but it's better to have them here to get rid of "missing await" warnings from compiler.

For methods that do not wait for the dispatched method, it is better to move the delay into the dispatched method and do not block the calling task for the delay time.