### PR TITLE
Fix rare exception in SetupExtendedSession on App startup

### DIFF
--- a/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
+++ b/Template10 (Library)/Common/Bootstrapper/BootStrapper.cs
@@ -524,7 +524,7 @@ namespace Template10.Common
                 SetupLifecycleListeners();
                 SetupSystemListeners();
                 SetupCustomTitleBar();
-                SetupExtendedSession();
+                await SetupExtendedSessionAsync();
 
                 await OnInitializeAsync(e);
                 CurrentState = BootstrapperStates.Initialized;
@@ -576,7 +576,7 @@ namespace Template10.Common
             }
         }
 
-        private async void SetupExtendedSession()
+        private async Task SetupExtendedSessionAsync()
         {
             var session = new ExtendedExecutionSession
             {


### PR DESCRIPTION
Fix rare exception in SetupExtendedSession caused by bad timing of "async void" method calling another "async void" method