### PR TITLE
Fix retrieving navigation parameter by key.

### DIFF
--- a/Source/Prism.Windows/Navigation/PageRegistry/PageRegistry.cs
+++ b/Source/Prism.Windows/Navigation/PageRegistry/PageRegistry.cs
@@ -22,6 +22,11 @@ namespace Prism.Navigation
             _cache.Add(key, info);
         }
 
+        public static void RemoveRegistration(string key)
+        {
+            _cache.Remove(key);
+        }
+
         public static bool TryGetRegistration(string key, out (string Key, Type View, Type ViewModel) info)
         {
             if (_cache.ContainsKey(key))

--- a/Source/Prism.Windows/Navigation/Prism.Core/NavigationParameters.cs
+++ b/Source/Prism.Windows/Navigation/Prism.Core/NavigationParameters.cs
@@ -45,7 +45,7 @@ namespace Prism.Navigation
 
         public T GetValue<T>(string key)
         {
-            return (T)Convert.ChangeType(_internal[key], typeof(T));
+            return (T)Convert.ChangeType(_external[key], typeof(T));
         }
 
         public IEnumerable<T> GetValues<T>(string key)

--- a/Source/Prism.Windows/Navigation/Prism.Core/NavigationParameters.cs
+++ b/Source/Prism.Windows/Navigation/Prism.Core/NavigationParameters.cs
@@ -17,7 +17,7 @@ namespace Prism.Navigation
         }
 
         public NavigationParameters(string query)
-            : this(new Windows.Foundation.WwwFormUrlDecoder(query).Select(x => (x.Name, (object)x.Value)).ToArray())
+            : this(string.IsNullOrWhiteSpace(query) ? Array.Empty<(string key, object value)>() : new Windows.Foundation.WwwFormUrlDecoder(query).Select(x => (x.Name, (object)x.Value)).ToArray())
         {
             // empty
         }

--- a/Source/Template10.Extras.10586/Services/Web/Abstractions/IWebApiAdapter.cs
+++ b/Source/Template10.Extras.10586/Services/Web/Abstractions/IWebApiAdapter.cs
@@ -5,6 +5,7 @@ namespace Template10.Services.Web
 {
     public interface IWebApiAdapter
     {
+        void AddHeader(string key, string value);
         Task DeleteAsync(Uri path);
         Task<string> GetAsync(Uri path);
         Task PostAsync(Uri path, string payload);

--- a/Source/Template10.Extras.10586/Services/Web/Abstractions/IWebApiService.cs
+++ b/Source/Template10.Extras.10586/Services/Web/Abstractions/IWebApiService.cs
@@ -6,6 +6,8 @@ namespace Template10.Services.Web
 {
     public interface IWebApiService
     {
+        void AddHeader(string key, string value);
+
         Task<string> GetAsync(Uri path);
 
         Task PutAsync<T>(Uri path, T payload);

--- a/Source/Template10.Extras.10586/Services/Web/Default/WebApiService.cs
+++ b/Source/Template10.Extras.10586/Services/Web/Default/WebApiService.cs
@@ -19,6 +19,11 @@ namespace Template10.Services.Web
             client.DefaultRequestHeaders.Accept.Add(header);
         }
 
+        public void AddHeader(string key, string value)
+        {
+            _adapter.AddHeader(key, value);
+        }
+
         public async Task<string> GetAsync(Uri path)
         {
             return await _adapter.GetAsync(path);

--- a/Source/Template10.Extras.10586/Services/Web/Default/WindowsHttpClientAdapter.cs
+++ b/Source/Template10.Extras.10586/Services/Web/Default/WindowsHttpClientAdapter.cs
@@ -16,6 +16,11 @@ namespace Template10.Services.Web
             client = _client = new HttpClient();
         }
 
+        public void AddHeader(string key, string value)
+        {
+            _client.DefaultRequestHeaders.Add(key, value);
+        }
+
         public async Task<string> GetAsync(Uri path)
         {
             var response = await _client.GetAsync(path);


### PR DESCRIPTION
I was using:

```c#
NavViewProps.SetNavigationUri(myNavItem, PathBuilder.Create("MusicPage", ("sectionKey", section.Key)).ToString());
```

And then trying to retrieve it:

```c#
_sectionKey = parameters.GetValue<string>("sectionKey");
```

which resulted in "the given key was not present in the dictionary." I think this is the correct fix for this, but I'm happy to modify it if not.