### PR TITLE
Fix back-stack being incorrectly cleared

### DIFF
--- a/Source/Prism.Windows/Navigation/PathBuilder.cs
+++ b/Source/Prism.Windows/Navigation/PathBuilder.cs
@@ -64,7 +64,7 @@ namespace Prism.Navigation
             }
             else
             {
-                var value = $"/{page}";
+                var value = $"{prefix}{page}";
                 return value;
             }
         }


### PR DESCRIPTION
This:
```
var path = PathBuilder.Create(BackStackBehaviors.Append, nameof(EditPage)).ToString();
```

used to produce this:

> "/EditPage"

Instead it should produce this:

> "EditPage"

which this PR fixes.