### PR TITLE
Fix retrieving navigation parameter by key

### DIFF
--- a/Source/Prism.Windows/Navigation/Prism.Core/NavigationParameters.cs
+++ b/Source/Prism.Windows/Navigation/Prism.Core/NavigationParameters.cs
@@ -45,7 +45,7 @@ namespace Prism.Navigation
 
         public T GetValue<T>(string key)
         {
-            return (T)Convert.ChangeType(_internal[key], typeof(T));
+            return (T)Convert.ChangeType(_external[key], typeof(T));
         }
 
         public IEnumerable<T> GetValues<T>(string key)

--- a/Source/Prism.Windows/Navigation/Prism.Core/NavigationParameters.cs
+++ b/Source/Prism.Windows/Navigation/Prism.Core/NavigationParameters.cs
@@ -17,7 +17,7 @@ namespace Prism.Navigation
         }
 
         public NavigationParameters(string query)
-            : this(new Windows.Foundation.WwwFormUrlDecoder(query).Select(x => (x.Name, (object)x.Value)).ToArray())
+            : this(string.IsNullOrWhiteSpace(query) ? Array.Empty<(string key, object value)>() : new Windows.Foundation.WwwFormUrlDecoder(query).Select(x => (x.Name, (object)x.Value)).ToArray())
         {
             // empty
         }


### PR DESCRIPTION
I was using:

```
NavViewProps.SetNavigationUri(myNavItem, PathBuilder.Create("MusicPage", ("sectionKey", section.Key)).ToString());
```
  

And then trying to retrieve it:
```
_sectionKey = parameters.GetValue<string>("sectionKey");
```
which resulted in "the given key was not present in the dictionary." I think this is the correct fix for this, but I'm happy to modify it if not.