### PR TITLE
Fix navigation parameters on GoBackAsync

### DIFF
--- a/Source/Prism.Windows/Navigation/NavigationService/NavigationService.cs
+++ b/Source/Prism.Windows/Navigation/NavigationService/NavigationService.cs
@@ -106,7 +106,7 @@ namespace Prism.Navigation
 
         public async Task<INavigationResult> GoBackAsync(INavigationParameters parameters)
             => await GoBackAsync(
-                parameters: default(INavigationParameters),
+                parameters: parameters,
                 infoOverride: default(NavigationTransitionInfo));
 
         public async Task<INavigationResult> GoBackAsync(INavigationParameters parameters = null, NavigationTransitionInfo infoOverride = null)


### PR DESCRIPTION
Previously, when navigation parameters were handed into `GoBackAsync`, the navigation service ignored them and used `default(INavigationParameters)`, which resulted in the navigation service using whatever parameters had originally been handed to the page. This change respects the provided parameters.