### PR TITLE
fix navigation path order (GetNavigationPath)

### DIFF
--- a/Source/Prism.Windows/Navigation/Extensions.cs
+++ b/Source/Prism.Windows/Navigation/Extensions.cs
@@ -24,7 +24,6 @@ namespace Prism.Navigation
             var nav = service as IPlatformNavigationService2;
             var facade = nav.FrameFacade as IFrameFacade2;
             var sb = new List<string>();
-            sb.Add(facade.CurrentNavigationPath);
             foreach (var item in facade.Frame.BackStack)
             {
                 if (PageRegistry.TryGetRegistration(item.SourcePageType, out var info))
@@ -46,6 +45,7 @@ namespace Prism.Navigation
                     }
                 }
             }
+            sb.Add(facade.CurrentNavigationPath);
             return $"/{string.Join("/", sb.ToArray())}";
         }
 


### PR DESCRIPTION
Solves a problem that the navigation path has a wrong order.
Sample navigation:
/MainPage
SettingPage?item=1
SettingPage?item=2

Currently it becomes /SettingPage?item=2/MainPage/SettingPage?item=1
and not /MainPage/SettingPage?item=1/SettingPage?item=2