### PR TITLE
Fix: Method not found: 'Void Newtonsoft.Json.JsonSerializerSettings.set_TypeNameAssemblyFormat'

### DIFF
--- a/Template10 (Library)/Services/FileService/FileHelper.cs
+++ b/Template10 (Library)/Services/FileService/FileHelper.cs
@@ -136,7 +136,7 @@ namespace Template10.Services.FileService
         private static string Serialize<T>(T item) => JsonConvert.SerializeObject(item, Formatting.None, new JsonSerializerSettings()
         {
             TypeNameHandling = TypeNameHandling.Objects,
-            TypeNameAssemblyFormat = System.Runtime.Serialization.Formatters.FormatterAssemblyStyle.Simple
+            TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple
         });
 
         private static T Deserialize<T>(string json) => JsonConvert.DeserializeObject<T>(json);

--- a/Template10 (Library)/Services/SerializationService/JsonSerializationService.cs
+++ b/Template10 (Library)/Services/SerializationService/JsonSerializationService.cs
@@ -26,7 +26,7 @@ namespace Template10.Services.SerializationService
             {
                 Formatting = Formatting.None,
                 TypeNameHandling = TypeNameHandling.Auto,
-                TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
+                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
                 PreserveReferencesHandling = PreserveReferencesHandling.All,
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                 ObjectCreationHandling = ObjectCreationHandling.Auto,


### PR DESCRIPTION
Use TypeNameAssemblyFormatHandling instead of obsolete TypeNameAssemblyFormat as described in https://github.com/JamesNK/Newtonsoft.Json/issues/1671. This will fix https://github.com/Windows-XAML/Template10/issues/1646